### PR TITLE
add configuration api key

### DIFF
--- a/peliculas-app/.gitignore
+++ b/peliculas-app/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+.env

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/config/ApiConfiguration.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/config/ApiConfiguration.java
@@ -1,0 +1,14 @@
+package com.peliculas.peliculasapp.infrastructure.config;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
+
+@Configuration
+public class ApiConfiguration {
+
+    @Value("${EXTERNAL_API_KEY}")
+    private String externalApiToken;
+
+    public String getExternalApiToken() {
+        return externalApiToken;
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
@@ -1,0 +1,8 @@
+package com.peliculas.peliculasapp.infrastructure.entities;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class ExternalMovieEntity {
+
+}


### PR DESCRIPTION
* Se ha agregado la clase `ApiConfiguration` en el paquete infrastructure.config.
`ApiConfiguration` proporciona un método para obtener el token de la API externa desde la configuración.

* Contexto:
Este cambio se realiza para centralizar la configuración relacionada con la API externa. La clase `ApiConfiguration` se utiliza en el adaptador `MovieDetailsAdapter` para obtener el token necesario al realizar llamadas a la API externa.