### PR TITLE
Añadidos controladores para Películas y Series de Televisión

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
@@ -1,0 +1,20 @@
+package com.peliculas.peliculasapp.infrastructure.controllers;
+
+import com.peliculas.peliculasapp.domain.ports.in.GetAndSaveInfoUseCase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+public class MovieController {
+    private final GetAndSaveInfoUseCase getAndSaveInfoUseCase;
+
+    @Autowired
+    public MovieController(GetAndSaveInfoUseCase getAndSaveInfoUseCase) {
+        this.getAndSaveInfoUseCase = getAndSaveInfoUseCase;
+    }
+
+    @GetMapping("/{id}")
+    public void getAndSaveMovieInfo(@PathVariable long id) {
+        getAndSaveInfoUseCase.getAndSaveMovieInfo(id);
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/TvSeriesController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/TvSeriesController.java
@@ -1,0 +1,25 @@
+package com.peliculas.peliculasapp.infrastructure.controllers;
+
+
+import com.peliculas.peliculasapp.domain.ports.in.GetAndSaveInfoUseCase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tvseries")
+public class TvSeriesController {
+    private final GetAndSaveInfoUseCase getAndSaveInfoUseCase;
+
+    @Autowired
+    public TvSeriesController(GetAndSaveInfoUseCase getAndSaveInfoUseCase) {
+        this.getAndSaveInfoUseCase = getAndSaveInfoUseCase;
+    }
+
+    @GetMapping("/{id}")
+    public void getAndSaveTvSeriesInfo(@PathVariable long id) {
+        getAndSaveInfoUseCase.getAndSaveTvSeriesInfo(id);
+    }
+}


### PR DESCRIPTION
### Descripción:
Este PR introduce dos nuevos controladores, `MovieController` y `TvSeriesController`, para gestionar las solicitudes relacionadas con películas y series de televisión, respectivamente. La adición de estos controladores permite una mejor organización y manejo de las funcionalidades relacionadas con el contenido multimedia.

Cambios Realizados:

Se creó `MovieController` para manejar solicitudes relacionadas con películas.
Se creó `TvSeriesController` para manejar solicitudes relacionadas con series de televisión.
Se añadió la lógica necesaria en el caso de uso `GetAndSaveInfoUseCase` para dar soporte a las nuevas funcionalidades.