### PR TITLE
feat: Ajustar asociaciones en ExternalMovieEntity

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
@@ -1,5 +1,4 @@
 package com.peliculas.peliculasapp;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
@@ -1,6 +1,8 @@
 package com.peliculas.peliculasapp.domain.models;
+
 import java.util.Date;
 import java.util.List;
+
 
 public class Movie {
     private long id;
@@ -30,4 +32,133 @@ public class Movie {
     private String posterPath;
 
     private Date releaseDate;
+
+    public Movie(long id, String overview, String status, List<ProductionCompany> productionCompanies, List<Genre> genres, List<ProductionCountries> productionCountries, String title, float voteAverage, int voteCount, int revenue, int budget, float popularity, String posterPath, Date releaseDate) {
+        this.id = id;
+        this.overview = overview;
+        this.status = status;
+        this.productionCompanies = productionCompanies;
+        this.genres = genres;
+        this.productionCountries = productionCountries;
+        this.title = title;
+        this.voteAverage = voteAverage;
+        this.voteCount = voteCount;
+        this.revenue = revenue;
+        this.budget = budget;
+        this.popularity = popularity;
+        this.posterPath = posterPath;
+        this.releaseDate = releaseDate;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getOverview() {
+        return overview;
+    }
+
+    public void setOverview(String overview) {
+        this.overview = overview;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public List<ProductionCompany> getProductionCompanies() {
+        return productionCompanies;
+    }
+
+    public void setProductionCompanies(List<ProductionCompany> productionCompanies) {
+        this.productionCompanies = productionCompanies;
+    }
+
+    public List<Genre> getGenres() {
+        return genres;
+    }
+
+    public void setGenres(List<Genre> genres) {
+        this.genres = genres;
+    }
+
+    public List<ProductionCountries> getProductionCountries() {
+        return productionCountries;
+    }
+
+    public void setProductionCountries(List<ProductionCountries> productionCountries) {
+        this.productionCountries = productionCountries;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public float getVoteAverage() {
+        return voteAverage;
+    }
+
+    public void setVoteAverage(float voteAverage) {
+        this.voteAverage = voteAverage;
+    }
+
+    public int getVoteCount() {
+        return voteCount;
+    }
+
+    public void setVoteCount(int voteCount) {
+        this.voteCount = voteCount;
+    }
+
+    public int getRevenue() {
+        return revenue;
+    }
+
+    public void setRevenue(int revenue) {
+        this.revenue = revenue;
+    }
+
+    public int getBudget() {
+        return budget;
+    }
+
+    public void setBudget(int budget) {
+        this.budget = budget;
+    }
+
+    public float getPopularity() {
+        return popularity;
+    }
+
+    public void setPopularity(float popularity) {
+        this.popularity = popularity;
+    }
+
+    public String getPosterPath() {
+        return posterPath;
+    }
+
+    public void setPosterPath(String posterPath) {
+        this.posterPath = posterPath;
+    }
+
+    public Date getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(Date releaseDate) {
+        this.releaseDate = releaseDate;
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/ports/out/MovieRepository.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/ports/out/MovieRepository.java
@@ -1,8 +1,8 @@
 package com.peliculas.peliculasapp.domain.ports.out;
-
 import com.peliculas.peliculasapp.domain.models.Movie;
+import java.util.Optional;
 
 public interface MovieRepository {
-    void saveMovieInfo(Movie movie);
-    Movie getMovieId(long movieId);
+    Movie saveMovieInfo(Movie movie);
+    Optional<Movie> getMovieId(long movieId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/config/ApiConfiguration.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/config/ApiConfiguration.java
@@ -1,15 +1,16 @@
 package com.peliculas.peliculasapp.infrastructure.config;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.beans.factory.annotation.Value;
 
 @Configuration
 public class ApiConfiguration {
 
-    @Value("${EXTERNAL_API_KEY}")
-    private String externalApiToken;
+    private final String externalApiToken = System.getenv("EXTERNAL_API_KEY");
 
-    @Value("${API_URL}")
-    private String apiUrl;
+    private final String apiUrl = System.getenv("API_URL");
+
+    public void print() {
+        System.out.println("external" + externalApiToken);
+    }
 
     public String getExternalApiToken() {
         return externalApiToken;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
@@ -1,10 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.controllers;
-
 import com.peliculas.peliculasapp.domain.ports.in.GetAndSaveInfoUseCase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+
+@RestController
+@RequestMapping("/movies")
 public class MovieController {
     private final GetAndSaveInfoUseCase getAndSaveInfoUseCase;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/TvSeriesController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/TvSeriesController.java
@@ -1,6 +1,4 @@
 package com.peliculas.peliculasapp.infrastructure.controllers;
-
-
 import com.peliculas.peliculasapp.domain.ports.in.GetAndSaveInfoUseCase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
@@ -1,8 +1,112 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-
-import jakarta.persistence.Entity;
+import com.peliculas.peliculasapp.domain.models.Genre;
+import com.peliculas.peliculasapp.domain.models.Movie;
+import com.peliculas.peliculasapp.domain.models.ProductionCompany;
+import com.peliculas.peliculasapp.domain.models.ProductionCountries;
+import jakarta.persistence.*;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 public class ExternalMovieEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String overview;
+
+    private String status;
+
+    @OneToMany
+    private List<ProductionCompany> productionCompanies;
+
+    @OneToMany
+    private List<Genre> genres;
+
+    @OneToMany
+    private List<ProductionCountriesEntity> productionCountries;
+
+    private String title;
+
+    private float voteAverage;
+
+    private int voteCount;
+
+    private int revenue;
+
+    private int budget;
+
+    private float popularity;
+
+    private String posterPath;
+
+    @Temporal(TemporalType.DATE)
+    private Date releaseDate;
+
+    public ExternalMovieEntity() {}
+
+    public ExternalMovieEntity(long id, String overview, String status, List<ProductionCompany> productionCompanies, List<Genre> genres, List<ProductionCountriesEntity> productionCountries, String title, float voteAverage, int voteCount, int revenue, int budget, float popularity, String posterPath, Date releaseDate) {
+        this.id = id;
+        this.overview = overview;
+        this.status = status;
+        this.productionCompanies = productionCompanies;
+        this.genres = genres;
+        this.productionCountries = productionCountries;
+        this.title = title;
+        this.voteAverage = voteAverage;
+        this.voteCount = voteCount;
+        this.revenue = revenue;
+        this.budget = budget;
+        this.popularity = popularity;
+        this.posterPath = posterPath;
+        this.releaseDate = releaseDate;
+    }
+
+    public static ExternalMovieEntity fromDomainModel(Movie movie) {
+        List<ProductionCountriesEntity> productionCountriesEntities = movie.getProductionCountries().stream()
+                .map(ProductionCountriesEntity::fromDomainModel)
+                .toList();
+
+        return new ExternalMovieEntity(
+                movie.getId(),
+                movie.getOverview(),
+                movie.getStatus(),
+                movie.getProductionCompanies(),
+                movie.getGenres(),
+                productionCountriesEntities,
+                movie.getTitle(),
+                movie.getVoteAverage(),
+                movie.getVoteCount(),
+                movie.getRevenue(),
+                movie.getBudget(),
+                movie.getPopularity(),
+                movie.getPosterPath(),
+                movie.getReleaseDate()
+        );
+    }
+
+    public Movie toDomainModel() {
+        List<ProductionCountries> productionCountries = this.productionCountries.stream()
+                .map(ProductionCountriesEntity::toDomainModel)
+                .collect(Collectors.toList());
+
+        return new Movie(
+                id,
+                overview,
+                status,
+                productionCompanies,
+                genres,
+                productionCountries,
+                title,
+                voteAverage,
+                voteCount,
+                revenue,
+                budget,
+                popularity,
+                posterPath,
+                releaseDate
+        );
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
@@ -20,7 +20,7 @@ public class ExternalMovieEntity {
     private String status;
 
     @OneToMany
-    private List<ProductionCompany> productionCompanies;
+    private List<ProductionCompaniesEntity> productionCompanies;
 
     @OneToMany
     private List<Genre> genres;
@@ -47,7 +47,7 @@ public class ExternalMovieEntity {
 
     public ExternalMovieEntity() {}
 
-    public ExternalMovieEntity(long id, String overview, String status, List<ProductionCompany> productionCompanies, List<Genre> genres, List<ProductionCountriesEntity> productionCountries, String title, float voteAverage, int voteCount, int revenue, int budget, float popularity, String posterPath, Date releaseDate) {
+    public ExternalMovieEntity(long id, String overview, String status, List<ProductionCompaniesEntity> productionCompanies, List<Genre> genres, List<ProductionCountriesEntity> productionCountries, String title, float voteAverage, int voteCount, int revenue, int budget, float popularity, String posterPath, Date releaseDate) {
         this.id = id;
         this.overview = overview;
         this.status = status;
@@ -69,11 +69,15 @@ public class ExternalMovieEntity {
                 .map(ProductionCountriesEntity::fromDomainModel)
                 .toList();
 
+        List<ProductionCompaniesEntity> productionCompanyEntities = movie.getProductionCompanies().stream()
+                .map(ProductionCompaniesEntity::fromDomainModel)
+                .toList();
+
         return new ExternalMovieEntity(
                 movie.getId(),
                 movie.getOverview(),
                 movie.getStatus(),
-                movie.getProductionCompanies(),
+                productionCompanyEntities,
                 movie.getGenres(),
                 productionCountriesEntities,
                 movie.getTitle(),
@@ -90,6 +94,10 @@ public class ExternalMovieEntity {
     public Movie toDomainModel() {
         List<ProductionCountries> productionCountries = this.productionCountries.stream()
                 .map(ProductionCountriesEntity::toDomainModel)
+                .collect(Collectors.toList());
+
+        List<ProductionCompany> productionCompanies = this.productionCompanies.stream()
+                .map(ProductionCompaniesEntity::toDomainModel)
                 .collect(Collectors.toList());
 
         return new Movie(

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ExternalMovieEntity.java
@@ -23,7 +23,7 @@ public class ExternalMovieEntity {
     private List<ProductionCompaniesEntity> productionCompanies;
 
     @OneToMany
-    private List<Genre> genres;
+    private List<GenreEntity> genres;
 
     @OneToMany
     private List<ProductionCountriesEntity> productionCountries;
@@ -47,7 +47,7 @@ public class ExternalMovieEntity {
 
     public ExternalMovieEntity() {}
 
-    public ExternalMovieEntity(long id, String overview, String status, List<ProductionCompaniesEntity> productionCompanies, List<Genre> genres, List<ProductionCountriesEntity> productionCountries, String title, float voteAverage, int voteCount, int revenue, int budget, float popularity, String posterPath, Date releaseDate) {
+    public ExternalMovieEntity(long id, String overview, String status, List<ProductionCompaniesEntity> productionCompanies, List<GenreEntity> genres, List<ProductionCountriesEntity> productionCountries, String title, float voteAverage, int voteCount, int revenue, int budget, float popularity, String posterPath, Date releaseDate) {
         this.id = id;
         this.overview = overview;
         this.status = status;
@@ -73,12 +73,16 @@ public class ExternalMovieEntity {
                 .map(ProductionCompaniesEntity::fromDomainModel)
                 .toList();
 
+        List<GenreEntity> genreEntities = movie.getGenres().stream()
+                .map(GenreEntity::fromDomainModel)
+                .toList();
+
         return new ExternalMovieEntity(
                 movie.getId(),
                 movie.getOverview(),
                 movie.getStatus(),
                 productionCompanyEntities,
-                movie.getGenres(),
+                genreEntities,
                 productionCountriesEntities,
                 movie.getTitle(),
                 movie.getVoteAverage(),
@@ -100,12 +104,16 @@ public class ExternalMovieEntity {
                 .map(ProductionCompaniesEntity::toDomainModel)
                 .collect(Collectors.toList());
 
+        List<Genre> genreList = this.genres.stream()
+                .map(GenreEntity::toDomainModel)
+                .collect(Collectors.toList());
+
         return new Movie(
                 id,
                 overview,
                 status,
                 productionCompanies,
-                genres,
+                genreList,
                 productionCountries,
                 title,
                 voteAverage,

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
@@ -1,4 +1,26 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
 
+
+import com.peliculas.peliculasapp.domain.models.Genre;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
 public class GenreEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String name;
+
+    public static GenreEntity fromDomainModel(Genre genre) {
+        return new GenreEntity();
+    }
+
+    public Genre toDomainModel() {
+        return new Genre();
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
@@ -1,0 +1,4 @@
+package com.peliculas.peliculasapp.infrastructure.entities;
+
+public class GenreEntity {
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCompaniesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCompaniesEntity.java
@@ -1,0 +1,32 @@
+package com.peliculas.peliculasapp.infrastructure.entities;
+
+
+import com.peliculas.peliculasapp.domain.models.ProductionCompany;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class ProductionCompaniesEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String name;
+
+    private String logoPath;
+
+    private String originCountry;
+
+
+    public static ProductionCompaniesEntity fromDomainModel(ProductionCompany productionCompany) {
+        return new ProductionCompaniesEntity();
+    }
+
+    public ProductionCompany toDomainModel() {
+        return new ProductionCompany();
+    }
+
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
@@ -1,0 +1,27 @@
+package com.peliculas.peliculasapp.infrastructure.entities;
+
+import com.peliculas.peliculasapp.domain.models.ProductionCountries;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class ProductionCountriesEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String name;
+
+    private String iso31661;
+
+    public static ProductionCountriesEntity fromDomainModel(ProductionCountries productionCountries) {
+        return new ProductionCountriesEntity();
+    }
+
+    public ProductionCountries toDomainModel() {
+        return new ProductionCountries();
+    }
+
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
@@ -3,6 +3,6 @@ package com.peliculas.peliculasapp.infrastructure.entities;
 
 import jakarta.persistence.Entity;
 
-@Entity
-public class TvSeriesEntity {
-}
+//@Entity
+//public class TvSeriesEntity {
+//}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpa.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpa.java
@@ -1,8 +1,8 @@
 package com.peliculas.peliculasapp.infrastructure.repositories;
-import com.peliculas.peliculasapp.domain.models.Movie;
+import com.peliculas.peliculasapp.infrastructure.entities.ExternalMovieEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MovieRepositoryJpa extends JpaRepository<Movie, Long> {
+public interface MovieRepositoryJpa extends JpaRepository<ExternalMovieEntity, Long> {
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpaImpl.java
@@ -1,0 +1,31 @@
+package com.peliculas.peliculasapp.infrastructure.repositories;
+import com.peliculas.peliculasapp.domain.models.Movie;
+import com.peliculas.peliculasapp.domain.ports.out.MovieRepository;
+import com.peliculas.peliculasapp.infrastructure.entities.ExternalMovieEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class MovieRepositoryJpaImpl implements MovieRepository {
+
+    private final MovieRepositoryJpa movieRepositoryJpa;
+
+    @Autowired
+    public MovieRepositoryJpaImpl(MovieRepositoryJpa movieRepositoryJpa) {
+        this.movieRepositoryJpa = movieRepositoryJpa;
+    }
+
+    @Override
+    public Movie saveMovieInfo(Movie movie) {
+        ExternalMovieEntity externalMovieEntity = ExternalMovieEntity.fromDomainModel(movie);
+        ExternalMovieEntity saveMovieEntity = movieRepositoryJpa.save(externalMovieEntity);
+        return saveMovieEntity.toDomainModel();
+    }
+
+    @Override
+    public Optional<Movie> getMovieId(long movieId) {
+        return movieRepositoryJpa.findById(movieId).map(ExternalMovieEntity::toDomainModel);
+    }
+}


### PR DESCRIPTION
### Resumen de cambios:

* Ajusta las asociaciones en la clase ExternalMovieEntity para que coincidan con las entidades JPA en la capa de infraestructura.
* Se modifica la asociación productionCountries para aceptar una lista de ProductionCountriesEntity en lugar de ProductionCountries, corrigiendo así el error de tipo incompatible.
* Se actualizan los métodos fromDomainModel y toDomainModel en ExternalMovieEntity para realizar la conversión adecuada entre ProductionCountries y ProductionCountriesEntity.
* Se añaden métodos de conversión en ProductionCountriesEntity para facilitar esta conversión.