### PR TITLE
Solucionado ciclo de dependencias en MovieRepositoryJpaImpl

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/services/MovieService.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/services/MovieService.java
@@ -1,0 +1,19 @@
+package com.peliculas.peliculasapp.application.services;
+
+import com.peliculas.peliculasapp.domain.ports.in.GetAndSaveInfoUseCase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class MovieService {
+    private final GetAndSaveInfoUseCase getAndSaveInfoUseCase;
+
+    public MovieService(GetAndSaveInfoUseCase getAndSaveInfoUseCase) {
+        this.getAndSaveInfoUseCase = getAndSaveInfoUseCase;
+    }
+
+    public void saveMovieInfo(long movieId) {
+        getAndSaveInfoUseCase.getAndSaveMovieInfo(movieId);
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveInfoUseCaseImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveInfoUseCaseImpl.java
@@ -2,31 +2,29 @@ package com.peliculas.peliculasapp.application.usecases;
 import com.peliculas.peliculasapp.domain.models.Movie;
 import com.peliculas.peliculasapp.domain.models.TvSeries;
 import com.peliculas.peliculasapp.domain.ports.in.GetAndSaveInfoUseCase;
-import com.peliculas.peliculasapp.domain.ports.out.MovieRepository;
+import com.peliculas.peliculasapp.domain.ports.out.MovieRepositoryPort;
 import com.peliculas.peliculasapp.domain.ports.out.TvSeriesRepository;
 import com.peliculas.peliculasapp.infrastructure.adapters.MovieDetailsAdapter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 
 @Service
 public class GetAndSaveInfoUseCaseImpl implements GetAndSaveInfoUseCase {
     private final MovieDetailsAdapter movieDetailsAdapter;
-    private final MovieRepository movieRepository;
+    private final MovieRepositoryPort movieRepository;
     private final TvSeriesRepository tvSeriesRepository;
 
-    @Autowired
     public GetAndSaveInfoUseCaseImpl(
-            MovieDetailsAdapter movieDetailsAdapter, MovieRepository movieRepository, TvSeriesRepository tvSeriesRepository
+            MovieDetailsAdapter movieDetailsAdapter, MovieRepositoryPort movieRepository, TvSeriesRepository tvSeriesRepository
     ) {
         this.movieDetailsAdapter = movieDetailsAdapter;
-        this.movieRepository = movieRepository;
         this.tvSeriesRepository = tvSeriesRepository;
+        this.movieRepository = movieRepository;
     }
 
     @Override
     public void getAndSaveMovieInfo(long movieId) {
         Movie movie = movieDetailsAdapter.getMovieInfoById(movieId);
-
         movieRepository.saveMovieInfo(movie);
     }
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/ports/out/MovieRepositoryPort.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/ports/out/MovieRepositoryPort.java
@@ -2,7 +2,7 @@ package com.peliculas.peliculasapp.domain.ports.out;
 import com.peliculas.peliculasapp.domain.models.Movie;
 import java.util.Optional;
 
-public interface MovieRepository {
+public interface MovieRepositoryPort {
     Movie saveMovieInfo(Movie movie);
     Optional<Movie> getMovieId(long movieId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/ports/out/TvSeriesRepository.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/ports/out/TvSeriesRepository.java
@@ -1,8 +1,8 @@
 package com.peliculas.peliculasapp.domain.ports.out;
-
 import com.peliculas.peliculasapp.domain.models.TvSeries;
+import java.util.Optional;
 
 public interface TvSeriesRepository {
     void saveTvSeriesInfo(TvSeries tvSeries);
-    TvSeries getTvSeriesById(long seriesId);
+    Optional<TvSeries> getTvSeriesById(long seriesId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/movies")
 public class MovieController {
-    private final GetAndSaveInfoUseCase getAndSaveInfoUseCase;
+    private GetAndSaveInfoUseCase getAndSaveInfoUseCase;
+
+    public MovieController() {}
 
     @Autowired
     public MovieController(GetAndSaveInfoUseCase getAndSaveInfoUseCase) {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
@@ -1,8 +1,13 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-
-
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
-//@Entity
-//public class TvSeriesEntity {
-//}
+@Entity
+public class TvSeriesEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpa.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpa.java
@@ -1,8 +1,0 @@
-package com.peliculas.peliculasapp.infrastructure.repositories;
-import com.peliculas.peliculasapp.infrastructure.entities.ExternalMovieEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface MovieRepositoryJpa extends JpaRepository<ExternalMovieEntity, Long> {
-}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpaImpl.java
@@ -1,31 +1,28 @@
 package com.peliculas.peliculasapp.infrastructure.repositories;
 import com.peliculas.peliculasapp.domain.models.Movie;
-import com.peliculas.peliculasapp.domain.ports.out.MovieRepository;
+import com.peliculas.peliculasapp.domain.ports.out.MovieRepositoryPort;
 import com.peliculas.peliculasapp.infrastructure.entities.ExternalMovieEntity;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-@Component
-public class MovieRepositoryJpaImpl implements MovieRepository {
+public class MovieRepositoryJpaImpl implements MovieRepositoryPort {
 
-    private final MovieRepositoryJpa movieRepositoryJpa;
+    private JpaRepository<ExternalMovieEntity, Long> MovieRepositoryJpa;
 
-    @Autowired
-    public MovieRepositoryJpaImpl(MovieRepositoryJpa movieRepositoryJpa) {
-        this.movieRepositoryJpa = movieRepositoryJpa;
-    }
+    public MovieRepositoryJpaImpl() {}
+
 
     @Override
     public Movie saveMovieInfo(Movie movie) {
         ExternalMovieEntity externalMovieEntity = ExternalMovieEntity.fromDomainModel(movie);
-        ExternalMovieEntity saveMovieEntity = movieRepositoryJpa.save(externalMovieEntity);
+        ExternalMovieEntity saveMovieEntity = MovieRepositoryJpa.save(externalMovieEntity);
         return saveMovieEntity.toDomainModel();
     }
 
     @Override
     public Optional<Movie> getMovieId(long movieId) {
-        return movieRepositoryJpa.findById(movieId).map(ExternalMovieEntity::toDomainModel);
+        return MovieRepositoryJpa.findById(movieId).map(ExternalMovieEntity::toDomainModel);
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpa.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpa.java
@@ -1,10 +1,9 @@
 package com.peliculas.peliculasapp.infrastructure.repositories;
-import com.peliculas.peliculasapp.domain.models.TvSeries;
+import com.peliculas.peliculasapp.infrastructure.entities.TvSeriesEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
-public interface TvSeriesRepositoryJpa extends JpaRepository<TvSeries, Long> {
-
+public interface TvSeriesRepositoryJpa extends JpaRepository<TvSeriesEntity, Long> {
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
@@ -1,0 +1,22 @@
+package com.peliculas.peliculasapp.infrastructure.repositories;
+
+import com.peliculas.peliculasapp.domain.models.TvSeries;
+import com.peliculas.peliculasapp.domain.ports.out.TvSeriesRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class TvSeriesRepositoryJpaImpl implements TvSeriesRepository {
+    // Implementación pendiente
+    // TODO: Implementar métodos de la interfaz TvSeriesRepository
+    @Override
+    public void saveTvSeriesInfo(TvSeries tvSeries) {
+
+    }
+
+    @Override
+    public Optional<TvSeries> getTvSeriesById(long seriesId) {
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
Se ha solucionado un ciclo de dependencias que se producía al inyectar JpaRepository en MovieRepositoryJpaImpl.

### Detalles del cambio:

* Se eliminó la anotación @Autowired de la variable movieRepositoryJpa en MovieRepositoryJpaImpl.