### PR TITLE
Eliminar constructor innecesario y obtener API Key correctamente

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
@@ -1,6 +1,7 @@
 package com.peliculas.peliculasapp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class PeliculasAppApplication {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/ApiConfiguration.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/ApiConfiguration.java
@@ -11,7 +11,9 @@ public class ApiConfiguration {
         return dotenv.get("API_URL");
     }
 
-    public String getApiKey() { return dotenv.get("EXTERNAL_API_KEY");}
+    public String getApiKey() {
+        return dotenv.get("EXTERNAL_API_KEY");
+    }
 
     public static void printAllEnvVariables() {
         System.out.println("Variables de entorno:");

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
@@ -1,5 +1,7 @@
 package com.peliculas.peliculasapp.domain.models;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -37,9 +39,9 @@ public class Movie {
         this.id = id;
         this.overview = overview;
         this.status = status;
-        this.productionCompanies = productionCompanies;
+        this.productionCompanies = Collections.emptyList();
         this.genres = genres;
-        this.productionCountries = productionCountries;
+        this.productionCountries = Collections.emptyList();
         this.title = title;
         this.voteAverage = voteAverage;
         this.voteCount = voteCount;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
@@ -2,6 +2,13 @@ package com.peliculas.peliculasapp.domain.models;
 
 public class ProductionCountries {
     private String name;
-
     private String iso31661;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getIso31661() {
+        return iso31661;
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
@@ -3,8 +3,12 @@ import com.peliculas.peliculasapp.application.config.ApiConfiguration;
 import com.peliculas.peliculasapp.domain.models.Movie;
 import com.peliculas.peliculasapp.domain.models.TvSeries;
 import com.peliculas.peliculasapp.application.ports.out.ExternalServicePort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
 
 @Component
 public class MovieDetailsAdapter implements ExternalServicePort {
@@ -18,8 +22,9 @@ public class MovieDetailsAdapter implements ExternalServicePort {
 
     @Override
     public Movie getMovieInfoById(long movieId) {
-        String endpoint = apiConfiguration.getApiUrl() + "movie/" + movieId + "?language=es-MX";
-        return new RestTemplate().getForObject(endpoint, Movie.class);
+        String endpoint = apiConfiguration.getApiUrl() + "movie/" + movieId + "?language=es-MX&api_key=" + apiConfiguration.getApiKey();
+        ResponseEntity<Movie> response = new RestTemplate().getForEntity(endpoint, Movie.class);
+        return response.getBody();
     }
 
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
@@ -3,12 +3,9 @@ import com.peliculas.peliculasapp.application.config.ApiConfiguration;
 import com.peliculas.peliculasapp.domain.models.Movie;
 import com.peliculas.peliculasapp.domain.models.TvSeries;
 import com.peliculas.peliculasapp.application.ports.out.ExternalServicePort;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.http.HttpHeaders;
 
 @Component
 public class MovieDetailsAdapter implements ExternalServicePort {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/controllers/MovieController.java
@@ -1,7 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.controllers;
-import com.peliculas.peliculasapp.application.ports.in.GetAndSaveInfoUseCase;
 import com.peliculas.peliculasapp.application.services.MovieService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,9 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/movies")
 public class MovieController {
-    private MovieService movieService;
+    private final MovieService movieService;
 
-    public MovieController() {}
 
     public MovieController(MovieService movieService) {
         this.movieService = movieService;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
@@ -1,20 +1,19 @@
-package com.peliculas.peliculasapp.infrastructure.entities;
+    package com.peliculas.peliculasapp.infrastructure.entities;
+    import com.peliculas.peliculasapp.domain.models.ProductionCountries;
+    import jakarta.persistence.Entity;
+    import jakarta.persistence.GeneratedValue;
+    import jakarta.persistence.GenerationType;
+    import jakarta.persistence.Id;
 
-import com.peliculas.peliculasapp.domain.models.ProductionCountries;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+    @Entity
+    public class ProductionCountriesEntity {
 
-@Entity
-public class ProductionCountriesEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private long id;
+        private String name;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
-    private String name;
-
-    private String iso31661;
+        private String iso31661;
 
     public static ProductionCountriesEntity fromDomainModel(ProductionCountries productionCountries) {
         return new ProductionCountriesEntity();

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepository.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepository.java
@@ -1,0 +1,9 @@
+package com.peliculas.peliculasapp.infrastructure.repositories;
+
+import com.peliculas.peliculasapp.infrastructure.entities.MovieEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MovieRepository extends JpaRepository<MovieEntity, Long> {
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieRepositoryJpaImpl.java
@@ -2,27 +2,28 @@ package com.peliculas.peliculasapp.infrastructure.repositories;
 import com.peliculas.peliculasapp.domain.models.Movie;
 import com.peliculas.peliculasapp.application.ports.out.MovieRepositoryPort;
 import com.peliculas.peliculasapp.infrastructure.entities.MovieEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import java.util.Optional;
 
-@Repository
+@Component
 public class MovieRepositoryJpaImpl implements MovieRepositoryPort {
+    private final MovieRepository movieRepositoryJpa;
 
-    private JpaRepository<MovieEntity, Long> MovieRepositoryJpa;
-
-    public MovieRepositoryJpaImpl() {}
+    @Autowired
+    public MovieRepositoryJpaImpl(MovieRepository movieRepository) {
+        this.movieRepositoryJpa = movieRepository;
+    }
 
     @Override
     public Movie findById(Movie movie) {
         MovieEntity externalMovieEntity = MovieEntity.fromDomainModel(movie);
-        MovieEntity saveMovieEntity = MovieRepositoryJpa.save(externalMovieEntity);
+        MovieEntity saveMovieEntity = movieRepositoryJpa.save(externalMovieEntity);
         return saveMovieEntity.toDomainModel();
     }
 
     @Override
     public Optional<Movie> findById(long movieId) {
-        return MovieRepositoryJpa.findById(movieId).map(MovieEntity::toDomainModel);
+        return movieRepositoryJpa.findById(movieId).map(MovieEntity::toDomainModel);
     }
 }


### PR DESCRIPTION
Se corrigieron dos errores relacionados con la obtención de información de películas:

* Se eliminó un constructor vacío del controller `MovieController` que causaba problemas con la inyección de dependencias.
* Se actualizó la forma en que se pasa la API Key a la API, ahora se envía como parámetro de consulta en la URL. Se verificó que la API Key sea válida y no tenga espacios adicionales.