### PR TITLE
Corregir error de persistencia al guardar películas 

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Genre.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Genre.java
@@ -4,4 +4,12 @@ public class Genre {
     private long id;
 
     private String name;
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
@@ -2,22 +2,32 @@ package com.peliculas.peliculasapp.infrastructure.entities;
 
 
 import com.peliculas.peliculasapp.domain.models.Genre;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 @Entity
 public class GenreEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private long id;
 
+    @Column(name = "name")
     private String name;
 
     public static GenreEntity fromDomainModel(Genre genre) {
-        return new GenreEntity();
+        GenreEntity genreEntity = new GenreEntity();
+        genreEntity.setId(genre.getId());
+        genreEntity.setName(genre.getName());
+        return genreEntity;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public Genre toDomainModel() {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/MovieEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/MovieEntity.java
@@ -22,7 +22,7 @@ public class MovieEntity {
     @OneToMany
     private List<ProductionCompaniesEntity> productionCompanies;
 
-    @OneToMany
+    @OneToMany(cascade = CascadeType.ALL)
     private List<GenreEntity> genres;
 
     @OneToMany


### PR DESCRIPTION
Detalles:
- Se agregó el método estático fromDomainModel para convertir objetos de dominio a entidades JPA.
- Se implementaron getters y setters para asegurar un acceso controlado a los campos de la entidad.