### PR TITLE
Implementar inyección de dependencias en MovieDetailsAdapter

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/RestTemplateConfig.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/RestTemplateConfig.java
@@ -1,0 +1,12 @@
+package com.peliculas.peliculasapp.application.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
@@ -9,10 +9,11 @@ import org.springframework.web.client.RestTemplate;
 
 @Component
 public class MovieDetailsAdapter implements ExternalServicePort {
-
     private final ApiConfiguration apiConfiguration;
+    private final RestTemplate restTemplate;
 
-    public MovieDetailsAdapter(ApiConfiguration apiConfiguration) {
+    public MovieDetailsAdapter(ApiConfiguration apiConfiguration, RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
         this.apiConfiguration = apiConfiguration;
     }
 
@@ -21,7 +22,7 @@ public class MovieDetailsAdapter implements ExternalServicePort {
     public Movie getMovieInfoById(long movieId) {
         // TODO: refactor
         String endpoint = apiConfiguration.getApiUrl() + "movie/" + movieId + "?language=es-MX&api_key=" + apiConfiguration.getApiKey();
-        ResponseEntity<Movie> response = new RestTemplate().getForEntity(endpoint, Movie.class);
+        ResponseEntity<Movie> response = restTemplate.getForEntity(endpoint, Movie.class);
         return response.getBody();
     }
 


### PR DESCRIPTION
Corregir error de inyección de dependencias en MovieDetailsAdapter

## Detalles:

## Error
* El commit aborda un problema donde la inyección de dependencias fallaba en la clase `MovieDetailsAdapter`.
* El error se producía porque Spring no podía encontrar un `bean` de tipo `RestTemplate` para inyectarlo en el constructor de `MovieDetailsAdapter`.

## Solucion
* Para solucionar este problema, se creó una clase de configuración `RestTemplateConfig` en el paquete `config`, donde se definió un `bean` de `RestTemplate`.
* La clase `RestTemplate` ahora está disponible para la inyección de dependencias en toda la aplicación.
Esto resuelve la excepción y permite que la inyección de dependencias funcione correctamente en `MovieDetailsAdapter`.
