### PR TITLE
handler error adapter

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
@@ -2,9 +2,10 @@ package com.peliculas.peliculasapp.infrastructure.adapters;
 import com.peliculas.peliculasapp.application.config.ApiConfiguration;
 import com.peliculas.peliculasapp.application.ports.out.MovieServicePort;
 import com.peliculas.peliculasapp.domain.models.Movie;
-import com.peliculas.peliculasapp.domain.models.TvSeries;
+import com.peliculas.peliculasapp.infrastructure.exceptions.MovieNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Component
@@ -20,9 +21,12 @@ public class MovieDetailsAdapter implements MovieServicePort {
 
     @Override
     public Movie getMovieInfoById(long movieId) {
-        // TODO: refactor
-        String endpoint = apiConfiguration.getApiUrl() + "movie/" + movieId + "?language=es-MX&api_key=" + apiConfiguration.getApiKey();
-        ResponseEntity<Movie> response = restTemplate.getForEntity(endpoint, Movie.class);
-        return response.getBody();
-    }
+        try {
+            String endpoint = apiConfiguration.getApiUrl() + "movie/" + movieId + "?language=es-MX&api_key=" + apiConfiguration.getApiKey();
+            ResponseEntity<Movie> response = restTemplate.getForEntity(endpoint, Movie.class);
+            return response.getBody();
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new MovieNotFoundException("Pelicula con ID: " + movieId + "no encontrada");
+        }
+        }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/exceptions/InfrastructureException.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/exceptions/InfrastructureException.java
@@ -1,7 +1,0 @@
-package com.peliculas.peliculasapp.infrastructure.exceptions;
-
-public abstract class InfrastructureException extends RuntimeException{
-    public InfrastructureException(String message) {
-        super(message);
-    }
-}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/exceptions/MovieNotFoundException.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/exceptions/MovieNotFoundException.java
@@ -1,0 +1,7 @@
+package com.peliculas.peliculasapp.infrastructure.exceptions;
+
+public class MovieNotFoundException extends RuntimeException {
+    public MovieNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Cambios Realizados:

* Se ha añadido un bloque `try-catch` al método `getMovieInfoById` para capturar excepciones `HttpClientErrorException`.
En caso de que se produzca un `error 404 (NotFound)` al intentar obtener información de una película, se lanza una excepción personalizada `MovieNotFoundException` con un mensaje descriptivo.
* Se ha definido la clase `MovieNotFoundException` como una subclase de `RuntimeException` para manejar los casos en los que no se encuentre una película con el ID especificado.