### PR TITLE
Implementación del adaptador getTvSeriesInfoById y la excepción TvSeriesNotFoundException

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/MovieDetailsAdapter.java
@@ -28,5 +28,5 @@ public class MovieDetailsAdapter implements MovieServicePort {
         } catch (HttpClientErrorException.NotFound e) {
             throw new MovieNotFoundException("Pelicula con ID: " + movieId + " no encontrada");
         }
-        }
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/SeriesDetailsAdapter.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapters/SeriesDetailsAdapter.java
@@ -2,15 +2,16 @@ package com.peliculas.peliculasapp.infrastructure.adapters;
 import com.peliculas.peliculasapp.application.config.ApiConfiguration;
 import com.peliculas.peliculasapp.application.ports.out.TvSeriesServicePort;
 import com.peliculas.peliculasapp.domain.models.TvSeries;
+import com.peliculas.peliculasapp.infrastructure.exceptions.TvSeriesNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 
 @Component
 public class SeriesDetailsAdapter implements TvSeriesServicePort {
     private final ApiConfiguration apiConfiguration;
-
     private final RestTemplate restTemplate;
 
     public SeriesDetailsAdapter(ApiConfiguration apiConfiguration, RestTemplate restTemplate) {
@@ -20,8 +21,12 @@ public class SeriesDetailsAdapter implements TvSeriesServicePort {
 
     @Override
     public TvSeries getTvSeriesInfoById(long tvSeriesId) {
-        String endpoint = apiConfiguration.getApiUrl() + "tv/" + tvSeriesId + "?language=es-MX";
-        ResponseEntity<TvSeries> response = restTemplate.getForEntity(endpoint, TvSeries.class);
-        return response.getBody();
+        try {
+            String endpoint = apiConfiguration.getApiUrl() + "tv/" + tvSeriesId + "?language=es-MX";
+            ResponseEntity<TvSeries> response = restTemplate.getForEntity(endpoint, TvSeries.class);
+            return response.getBody();
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new TvSeriesNotFoundException("Serie con ID: " + tvSeriesId + " no encontrada");
+        }
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/exceptions/TvSeriesNotFoundException.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/exceptions/TvSeriesNotFoundException.java
@@ -1,0 +1,7 @@
+package com.peliculas.peliculasapp.infrastructure.exceptions;
+
+public class TvSeriesNotFoundException extends RuntimeException{
+    public TvSeriesNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
##  Descripción:

- Este PR implementa el método `getTvSeriesInfoById` en el adaptador `SeriesDetailsAdapter` y la excepción personalizada `TvSeriesNotFoundException`.

#### Detalles de la implementación:

* Se ha implementado el método `getTvSeriesInfoById` en el adaptador `SeriesDetailsAdapter`. Este método:
Obtiene la información de la serie de TV con el ID especificado de la API externa.
* Si la serie de TV no se encuentra, se lanza la excepción TvSeriesNotFoundException.
* Se ha creado la excepción personalizada `TvSeriesNotFoundException`. Esta excepción se lanza cuando no se encuentra la serie de TV con el ID especificado.