### PR TITLE
Añadidos métodos fromDomainModel y toDomainModel en cada entidad

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
@@ -1,8 +1,9 @@
 package com.peliculas.peliculasapp.domain.models;
-
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class LastEpisode {
     private int id;
     private String name;
@@ -16,4 +17,6 @@ public class LastEpisode {
     private int season_number;
     private int show_id;
     private String still_path;
+
+
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
@@ -1,6 +1,5 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.Data;
-import java.util.Collections;
 import java.util.List;
 
 @Data
@@ -37,9 +36,9 @@ public class Movie {
         this.id = id;
         this.overview = overview;
         this.status = status;
-        this.production_companies = Collections.emptyList();
+        this.production_companies = productionCompanies;
         this.genres = genres;
-        this.production_countries = Collections.emptyList();
+        this.production_countries = productionCountries;
         this.title = title;
         this.vote_average = voteAverage;
         this.vote_count = voteCount;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Networks.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Networks.java
@@ -1,7 +1,9 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class Networks {
     private String logo_path;
     private String name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/NextEpisode.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/NextEpisode.java
@@ -1,7 +1,11 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class NextEpisode {
     private int id;
     private String name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Seasons.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Seasons.java
@@ -1,13 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class Seasons {
     private String air_date;
 
     private int episode_count;
-
-    private long id;
 
     private String name;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/SpokenLanguages.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/SpokenLanguages.java
@@ -1,7 +1,9 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class SpokenLanguages {
     private String english_name;
     private String iso_639_1;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/TvSeries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/TvSeries.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 @Data
 public class TvSeries {
-
     private long id;
     private String backdrop_path;
     private List<CreatedSeries> created_by;
@@ -34,4 +33,35 @@ public class TvSeries {
     private float vote_average;
     private int vote_count;
 
+
+    public TvSeries(long id, String backdrop_path, List<CreatedSeries> created_by, String first_air_date, List<Genre> genres, String homepage, boolean in_production, String last_air_date, LastEpisode last_episode_to_air, String name, NextEpisode next_episode_to_air, List<Networks> networks, int number_of_episodes, int number_of_seasons, List<String> origin_country, String original_language, String original_name, String overview, float popularity, String poster_path, List<ProductionCompany> production_companies, List<ProductionCountries> production_countries, List<Seasons> seasons, List<SpokenLanguages> spoken_languages, String status, String tagline, float vote_average, int vote_count) {
+        this.id = id;
+        this.backdrop_path = backdrop_path;
+        this.created_by = created_by;
+        this.first_air_date = first_air_date;
+        this.genres = genres;
+        this.homepage = homepage;
+        this.in_production = in_production;
+        this.last_air_date = last_air_date;
+        this.last_episode_to_air = last_episode_to_air;
+        this.name = name;
+        this.next_episode_to_air = next_episode_to_air;
+        this.networks = networks;
+        this.number_of_episodes = number_of_episodes;
+        this.number_of_seasons = number_of_seasons;
+        this.origin_country = origin_country;
+        this.original_language = original_language;
+        this.original_name = original_name;
+        this.overview = overview;
+        this.popularity = popularity;
+        this.poster_path = poster_path;
+        this.production_companies = production_companies;
+        this.production_countries = production_countries;
+        this.seasons = seasons;
+        this.spoken_languages = spoken_languages;
+        this.status = status;
+        this.tagline = tagline;
+        this.vote_average = vote_average;
+        this.vote_count = vote_count;
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/CreatedSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/CreatedSeriesEntity.java
@@ -1,4 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
+import com.peliculas.peliculasapp.domain.models.CreatedSeries;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -9,13 +10,16 @@ public class CreatedSeriesEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    private long credit_id;
-
     private String name;
-
     private int gender;
+    private String profilePath;
 
-    private String profile_path;
+    public static CreatedSeriesEntity fromDomainModel(CreatedSeries createdSeries) {
+        return new CreatedSeriesEntity();
+    }
+
+    public CreatedSeries toDomainModel() {
+        return new CreatedSeries();
+    }
 
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/LastEpisodeEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/LastEpisodeEntity.java
@@ -1,4 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
+import com.peliculas.peliculasapp.domain.models.LastEpisode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,4 +21,52 @@ public class LastEpisodeEntity {
     private int season_number;
     private int show_id;
     private String still_path;
+
+    public LastEpisodeEntity() {}
+
+    public LastEpisodeEntity(String name, String overview, float vote_count, String air_date, int episode_number, String episode_type, String production_code, int runtime, int season_number, int show_id, String still_path) {
+        this.name = name;
+        this.overview = overview;
+        this.vote_count = vote_count;
+        this.air_date = air_date;
+        this.episode_number = episode_number;
+        this.episode_type = episode_type;
+        this.production_code = production_code;
+        this.runtime = runtime;
+        this.season_number = season_number;
+        this.show_id = show_id;
+        this.still_path = still_path;
+    }
+
+    public LastEpisode toDomainModel() {
+        return new LastEpisode(
+                id,
+                name,
+                overview,
+                vote_count,
+                air_date,
+                episode_number,
+                episode_type,
+                production_code,
+                runtime,
+                season_number,
+                show_id,
+                still_path
+        );
+    }
+    public static LastEpisodeEntity fromDomainModel(LastEpisode lastEpisode) {
+        return new LastEpisodeEntity(
+                lastEpisode.getName(),
+                lastEpisode.getOverview(),
+                lastEpisode.getVote_count(),
+                lastEpisode.getAir_date(),
+                lastEpisode.getEpisode_number(),
+                lastEpisode.getEpisode_type(),
+                lastEpisode.getProduction_code(),
+                lastEpisode.getRuntime(),
+                lastEpisode.getSeason_number(),
+                lastEpisode.getShow_id(),
+                lastEpisode.getStill_path()
+        );
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NetworksEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NetworksEntity.java
@@ -1,4 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
+import com.peliculas.peliculasapp.domain.models.Networks;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,4 +13,28 @@ public class NetworksEntity {
     private String logo_path;
     private String name;
     private String origin_country;
+
+    public NetworksEntity(String logo_path, String name, String origin_country) {
+        this.logo_path = logo_path;
+        this.name = name;
+        this.origin_country = origin_country;
+    }
+
+    public NetworksEntity() {}
+
+    public Networks toDomainModel() {
+        return new Networks(
+                logo_path,
+                name,
+                origin_country
+        );
+    }
+
+    public static NetworksEntity fromDomainModel(Networks networks) {
+        return new NetworksEntity(
+                networks.getLogo_path(),
+                networks.getName(),
+                networks.getOrigin_country()
+        );
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NextEpisodeEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NextEpisodeEntity.java
@@ -1,5 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-
+import com.peliculas.peliculasapp.domain.models.NextEpisode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -22,4 +22,57 @@ public class NextEpisodeEntity {
     private int season_number;
     private int show_id;
     private String still_path;
+
+    public NextEpisodeEntity() {}
+
+    public NextEpisodeEntity(String name, String overview, float vote_average, int vote_count, String air_date, int episode_number, String episode_type, String production_code, int runtime, int season_number, int show_id, String still_path) {
+        this.name = name;
+        this.overview = overview;
+        this.vote_average = vote_average;
+        this.vote_count = vote_count;
+        this.air_date = air_date;
+        this.episode_number = episode_number;
+        this.episode_type = episode_type;
+        this.production_code = production_code;
+        this.runtime = runtime;
+        this.season_number = season_number;
+        this.show_id = show_id;
+        this.still_path = still_path;
+    }
+
+    public NextEpisode toDomainModel() {
+        return new NextEpisode(
+                id,
+                name,
+                overview,
+                vote_average,
+                vote_count,
+                air_date,
+                episode_number,
+                episode_type,
+                production_code,
+                runtime,
+                season_number,
+                show_id,
+                still_path
+        );
+    }
+
+    public static NextEpisodeEntity fromDomainModel(NextEpisode nextEpisode) {
+        return new NextEpisodeEntity(
+                nextEpisode.getName(),
+                nextEpisode.getOverview(),
+                nextEpisode.getVote_average(),
+                nextEpisode.getVote_count(),
+                nextEpisode.getAir_date(),
+                nextEpisode.getEpisode_number(),
+                nextEpisode.getEpisode_type(),
+                nextEpisode.getProduction_code(),
+                nextEpisode.getRuntime(),
+                nextEpisode.getSeason_number(),
+                nextEpisode.getShow_id(),
+                nextEpisode.getStill_path()
+        );
+    }
+
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/OriginCountryEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/OriginCountryEntity.java
@@ -3,6 +3,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+
 
 @Entity
 public class OriginCountryEntity {
@@ -10,4 +12,18 @@ public class OriginCountryEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
     private String name;
+
+    public OriginCountryEntity() {}
+
+    public OriginCountryEntity(String name) {
+        this.name = name;
+    }
+
+    public String toDomainModel() {
+        return this.name;
+    }
+
+    public static OriginCountryEntity fromDomainModel(String country) {
+        return new OriginCountryEntity(country);
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SeasonsEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SeasonsEntity.java
@@ -1,4 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
+import com.peliculas.peliculasapp.domain.models.Seasons;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -22,4 +23,40 @@ public class SeasonsEntity {
     private int seasonNumber;
 
     private float voteAverage;
+
+    public SeasonsEntity() {}
+
+    public SeasonsEntity(String airDate, int episodeCount, String name, String overview, String posterPath, int seasonNumber, float voteAverage) {
+        this.airDate = airDate;
+        this.episodeCount = episodeCount;
+        this.name = name;
+        this.overview = overview;
+        this.posterPath = posterPath;
+        this.seasonNumber = seasonNumber;
+        this.voteAverage = voteAverage;
+    }
+
+    public Seasons toDomainModel() {
+        return new Seasons(
+                airDate,
+                episodeCount,
+                name,
+                overview,
+                posterPath,
+                seasonNumber,
+                voteAverage
+        );
+    }
+
+    public static SeasonsEntity fromDomainModel(Seasons seasons) {
+        return new SeasonsEntity(
+                seasons.getAir_date(),
+                seasons.getEpisode_count(),
+                seasons.getName(),
+                seasons.getOverview(),
+                seasons.getPoster_path(),
+                seasons.getSeason_number(),
+                seasons.getVote_average()
+        );
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SpokenLanguagesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SpokenLanguagesEntity.java
@@ -1,4 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
+import com.peliculas.peliculasapp.domain.models.SpokenLanguages;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,4 +13,29 @@ public class SpokenLanguagesEntity {
     private String english_name;
     private String iso_639_1;
     private String name;
+
+    public SpokenLanguagesEntity(String english_name, String iso_639_1, String name) {
+        this.english_name = english_name;
+        this.iso_639_1 = iso_639_1;
+        this.name = name;
+    }
+
+    public SpokenLanguages toDomainModel() {
+        return new SpokenLanguages(
+                english_name,
+                iso_639_1,
+                name
+        );
+    }
+
+    public SpokenLanguagesEntity() {}
+
+
+    public static SpokenLanguagesEntity fromDomainModel(SpokenLanguages spokenLanguages) {
+        return new SpokenLanguagesEntity(
+                spokenLanguages.getEnglish_name(),
+                spokenLanguages.getIso_639_1(),
+                spokenLanguages.getName()
+        );
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
@@ -1,63 +1,245 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
+import com.peliculas.peliculasapp.domain.models.*;
 import jakarta.persistence.*;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Entity
 public class TvSeriesEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-    private String backdrop_path;
+    private String backdropPath;
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id")
-    private List<CreatedSeriesEntity> created_by;
-    private String first_air_date;
+    private List<CreatedSeriesEntity> createdBy;
+    private String firstAirDate;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id", referencedColumnName = "id")
     private List<GenreEntity> genres;
-    private String homepage;
-    private boolean in_production;
-    private String last_air_date;
+    private String homePage;
+    private boolean inProduction;
+    private String lastAirDate;
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "last_episode_id")
-    private LastEpisodeEntity last_episode_to_air;
+    private LastEpisodeEntity lastEpisodeToAir;
     private String name;
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "next_episode_id")
-    private NextEpisodeEntity next_episode_to_air;
+    private NextEpisodeEntity nextEpisodeToAir;
 
-    @ManyToOne
-    @JoinColumn(name = "networks_id")
-    private NetworksEntity networks;
-    private int number_of_episodes;
-    private int number_of_seasons;
+    @ManyToMany(cascade = CascadeType.ALL)
+    @JoinTable(
+            name = "tv_series_networks",
+            joinColumns = @JoinColumn(name = "tv_series_id"),
+            inverseJoinColumns = @JoinColumn(name = "networks_id")
+    )
+    private List<NetworksEntity> networks;
+    private int numberOfEpisodes;
+    private int numberOfSeasons;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id")
-    private List<OriginCountryEntity> origin_country;
-    private String original_language;
-    private String original_name;
+    private List<OriginCountryEntity> originCountry;
+    private String originalLanguage;
+    private String originalName;
     private String overview;
     private float popularity;
-    private String poster_path;
+    private String posterPath;
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id")
-    private List<ProductionCompaniesEntity> production_companies;
+    private List<ProductionCompaniesEntity> productionCompanies;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id")
-    private List<ProductionCountriesEntity> production_countries;
+    private List<ProductionCountriesEntity> productionCountries;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id")
     private List<SeasonsEntity> seasons;
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id")
-    private List<SpokenLanguagesEntity> spoken_languages;
+    private List<SpokenLanguagesEntity> spokenLanguages;
     private String status;
     private String tagline;
-    private float vote_average;
-    private int vote_count;
+    private float voteAverage;
+    private int voteCount;
+
+    public TvSeriesEntity() {}
+
+    public TvSeriesEntity(long id, String backdropPath, List<CreatedSeriesEntity> createdBy, String firstAirDate, List<GenreEntity> genres, String homePage, boolean inProduction, String lastAirDate, LastEpisodeEntity lastEpisodeToAir, String name, NextEpisodeEntity nextEpisodeToAir, List<NetworksEntity> networks, int numberOfEpisodes, int numberOfSeasons, List<OriginCountryEntity> originCountry, String originalLanguage, String originalName, String overview, float popularity, String posterPath, List<ProductionCompaniesEntity> productionCompanies, List<ProductionCountriesEntity> productionCountries, List<SeasonsEntity> seasons, List<SpokenLanguagesEntity> spokenLanguages, String status, String tagline, float voteAverage, int voteCount) {
+        this.id = id;
+        this.backdropPath = backdropPath;
+        this.createdBy = createdBy;
+        this.firstAirDate = firstAirDate;
+        this.genres = genres;
+        this.homePage = homePage;
+        this.inProduction = inProduction;
+        this.lastAirDate = lastAirDate;
+        this.lastEpisodeToAir = lastEpisodeToAir;
+        this.name = name;
+        this.nextEpisodeToAir = nextEpisodeToAir;
+        this.networks = networks;
+        this.numberOfEpisodes = numberOfEpisodes;
+        this.numberOfSeasons = numberOfSeasons;
+        this.originCountry = originCountry;
+        this.originalLanguage = originalLanguage;
+        this.originalName = originalName;
+        this.overview = overview;
+        this.popularity = popularity;
+        this.posterPath = posterPath;
+        this.productionCompanies = productionCompanies;
+        this.productionCountries = productionCountries;
+        this.seasons = seasons;
+        this.spokenLanguages = spokenLanguages;
+        this.status = status;
+        this.tagline = tagline;
+        this.voteAverage = voteAverage;
+        this.voteCount = voteCount;
+    }
+
+    public static TvSeriesEntity fromDomainModel(TvSeries tvSeries) {
+        List<CreatedSeriesEntity> createdSeriesEntityList = tvSeries.getCreated_by().stream()
+                .map(CreatedSeriesEntity::fromDomainModel)
+                .toList();
+
+        List<GenreEntity> genreEntityList = tvSeries.getGenres().stream()
+                .map(GenreEntity::fromDomainModel)
+                .toList();
+
+        LastEpisodeEntity lastEpisodeEntity = tvSeries.getLast_episode_to_air() != null ?
+                LastEpisodeEntity.fromDomainModel(tvSeries.getLast_episode_to_air()) :
+                null;
+
+        NextEpisodeEntity nextEpisodeEntity = tvSeries.getNext_episode_to_air() != null ?
+                NextEpisodeEntity.fromDomainModel(tvSeries.getNext_episode_to_air()) :
+                null;
+
+        List<NetworksEntity> networksEntity = tvSeries.getNetworks().stream()
+                .map(NetworksEntity::fromDomainModel)
+                .toList();
+
+        List<OriginCountryEntity> originCountryEntities = tvSeries.getOrigin_country().stream()
+                .map(OriginCountryEntity::fromDomainModel)
+                .toList();
+
+        List<ProductionCountriesEntity> productionCountriesEntities = tvSeries.getProduction_countries().stream()
+                .map(ProductionCountriesEntity::fromDomainModel)
+                .toList();
+
+        List<ProductionCompaniesEntity> productionCompanyEntities = tvSeries.getProduction_companies().stream()
+                .map(ProductionCompaniesEntity::fromDomainModel)
+                .toList();
+
+        List<SeasonsEntity> seasonsEntities = tvSeries.getSeasons().stream()
+                .map(SeasonsEntity::fromDomainModel)
+                .toList();
+
+        List<SpokenLanguagesEntity> spokenLanguagesEntities = tvSeries.getSpoken_languages().stream()
+                .map(SpokenLanguagesEntity::fromDomainModel)
+                .toList();
+
+        return new TvSeriesEntity(
+                tvSeries.getId(),
+                tvSeries.getBackdrop_path(),
+                createdSeriesEntityList,
+                tvSeries.getFirst_air_date(),
+                genreEntityList,
+                tvSeries.getHomepage(),
+                tvSeries.isIn_production(),
+                tvSeries.getLast_air_date(),
+                lastEpisodeEntity,
+                tvSeries.getName(),
+                nextEpisodeEntity,
+                networksEntity,
+                tvSeries.getNumber_of_episodes(),
+                tvSeries.getNumber_of_seasons(),
+                originCountryEntities,
+                tvSeries.getOriginal_language(),
+                tvSeries.getOriginal_name(),
+                tvSeries.getOverview(),
+                tvSeries.getPopularity(),
+                tvSeries.getPoster_path(),
+                productionCompanyEntities,
+                productionCountriesEntities,
+                seasonsEntities,
+                spokenLanguagesEntities,
+                tvSeries.getStatus(),
+                tvSeries.getTagline(),
+                tvSeries.getVote_average(),
+                tvSeries.getVote_count()
+
+        );
+    }
+
+    public Optional<TvSeries> toDomainModel() {
+        List<CreatedSeries> createdSeries = this.createdBy.stream()
+                .map(CreatedSeriesEntity::toDomainModel)
+                .toList();
+
+        List<Genre> genreList = this.genres.stream()
+                .map(GenreEntity::toDomainModel)
+                .toList();
+
+        LastEpisode lastEpisodeList = this.lastEpisodeToAir.toDomainModel();
+
+        NextEpisode nextEpisodeList = this.nextEpisodeToAir.toDomainModel();
+
+        List<Networks> networksList = this.networks.stream()
+                .map(NetworksEntity::toDomainModel)
+                .toList();
+
+        List<String> originCountryList = this.originCountry.stream()
+                .map(OriginCountryEntity::toDomainModel)
+                .toList();
+
+        List<ProductionCountries> productionCountries = this.productionCountries.stream()
+                .map(ProductionCountriesEntity::toDomainModel)
+                .collect(Collectors.toList());
+
+        List<ProductionCompany> productionCompanies = this.productionCompanies.stream()
+                .map(ProductionCompaniesEntity::toDomainModel)
+                .collect(Collectors.toList());
+
+        List<Seasons> seasonsList = this.seasons.stream()
+                .map(SeasonsEntity::toDomainModel)
+                .toList();
+
+        List<SpokenLanguages> spokenLanguagesList = this.spokenLanguages.stream()
+                .map(SpokenLanguagesEntity::toDomainModel)
+                .toList();
+
+        return Optional.of(new TvSeries(
+                id,
+                backdropPath,
+                createdSeries,
+                firstAirDate,
+                genreList,
+                homePage,
+                inProduction,
+                lastAirDate,
+                lastEpisodeList,
+                name,
+                nextEpisodeList,
+                networksList,
+                numberOfEpisodes,
+                numberOfSeasons,
+                originCountryList,
+                originalLanguage,
+                originalName,
+                overview,
+                popularity,
+                posterPath,
+                productionCompanies,
+                productionCountries,
+                seasonsList,
+                spokenLanguagesList,
+                status,
+                tagline,
+                voteAverage,
+                voteCount
+        ));
+    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
@@ -1,6 +1,7 @@
 package com.peliculas.peliculasapp.infrastructure.repositories;
 import com.peliculas.peliculasapp.domain.models.TvSeries;
 import com.peliculas.peliculasapp.application.ports.out.TvSeriesRepositoryPort;
+import com.peliculas.peliculasapp.infrastructure.entities.TvSeriesEntity;
 import com.peliculas.peliculasapp.infrastructure.exceptions.TvSeriesAlreadyExistsException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -20,8 +21,9 @@ public class TvSeriesRepositoryJpaImpl implements TvSeriesRepositoryPort {
           if (tvSeriesRepositoryJpa.existsById(tvSeries.getId())) {
               throw new TvSeriesAlreadyExistsException("Esta serie ya se encuentra guardada");
           }
-          TvSeries series = new TvSeries();
-          return Optional.of(series);
+          TvSeriesEntity tvSeriesEntity = TvSeriesEntity.fromDomainModel(tvSeries);
+          TvSeriesEntity savedTvSeries = tvSeriesRepositoryJpa.save(tvSeriesEntity);
+          return savedTvSeries.toDomainModel();
         } catch (TvSeriesAlreadyExistsException e) {
             throw new TvSeriesAlreadyExistsException("Esta serie ya se encuentra guardada");
         }


### PR DESCRIPTION
Añadir métodos `fromDomainModel` y `toDomainModel` en cada entidad

Esta solicitud de extracción agrega los métodos `fromDomainModel` y `toDomainModel` en cada entidad del proyecto. Estos métodos proporcionan funcionalidad para convertir objetos del modelo de dominio a entidades de persistencia y viceversa. La adición de estos métodos mejora la modularidad del código y facilita la gestión de la lógica de conversión entre capas. Además, esta mejora promueve una mejor separación de preocupaciones y un código más limpio y mantenible.
