### PR TITLE
[Feature]: Implementación de métodos fromDomainModel y toDomainModel en entidades relacionadas

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/CreatedSeries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/CreatedSeries.java
@@ -1,7 +1,9 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class CreatedSeries {
 
     private String name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Genre.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Genre.java
@@ -1,10 +1,10 @@
 package com.peliculas.peliculasapp.domain.models;
-
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class Genre {
-    private long id;
 
     private String name;
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCompany.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCompany.java
@@ -1,9 +1,10 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class ProductionCompany {
-    private long id;
 
     private String name;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
@@ -1,7 +1,9 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class ProductionCountries {
     private String name;
     private String iso_3166_1;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/CreatedSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/CreatedSeriesEntity.java
@@ -14,12 +14,28 @@ public class CreatedSeriesEntity {
     private int gender;
     private String profilePath;
 
+    public CreatedSeriesEntity() {}
+
+    public CreatedSeriesEntity(String name, int gender, String profilePath) {
+        this.name = name;
+        this.gender = gender;
+        this.profilePath = profilePath;
+    }
+
     public static CreatedSeriesEntity fromDomainModel(CreatedSeries createdSeries) {
-        return new CreatedSeriesEntity();
+        return new CreatedSeriesEntity(
+                createdSeries.getName(),
+                createdSeries.getGender(),
+                createdSeries.getProfile_path()
+        );
     }
 
     public CreatedSeries toDomainModel() {
-        return new CreatedSeries();
+        return new CreatedSeries(
+                name,
+                gender,
+                profilePath
+        );
     }
 
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
@@ -1,9 +1,7 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
 import com.peliculas.peliculasapp.domain.models.Genre;
 import jakarta.persistence.*;
-import lombok.Data;
 
-@Data
 @Entity
 public class GenreEntity {
 
@@ -13,12 +11,20 @@ public class GenreEntity {
 
     private String name;
 
+    public GenreEntity() {}
+
+    public GenreEntity(String name) {
+        this.name = name;
+    }
+
     public static GenreEntity fromDomainModel(Genre genre) {
-        GenreEntity genreEntity = new GenreEntity();
-        genreEntity.setName(genre.getName());
-        return genreEntity;
+        return new GenreEntity(
+                genre.getName()
+        );
     }
     public Genre toDomainModel() {
-        return new Genre();
+        return new Genre(
+                name
+        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NetworksEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NetworksEntity.java
@@ -1,9 +1,6 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
 import com.peliculas.peliculasapp.domain.models.Networks;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 @Entity
 public class NetworksEntity {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCompaniesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCompaniesEntity.java
@@ -1,6 +1,4 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-
-
 import com.peliculas.peliculasapp.domain.models.ProductionCompany;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,13 +18,29 @@ public class ProductionCompaniesEntity {
 
     private String originCountry;
 
+    public ProductionCompaniesEntity() {}
+
+    private ProductionCompaniesEntity(String name, String logoPath, String originCountry) {
+        this.name = name;
+        this.logoPath = logoPath;
+        this.originCountry = originCountry;
+    }
+
 
     public static ProductionCompaniesEntity fromDomainModel(ProductionCompany productionCompany) {
-        return new ProductionCompaniesEntity();
+        return new ProductionCompaniesEntity(
+                productionCompany.getName(),
+                productionCompany.getLogo_path(),
+                productionCompany.getOrigin_country()
+        );
     }
 
     public ProductionCompany toDomainModel() {
-        return new ProductionCompany();
+        return new ProductionCompany(
+                name,
+                logoPath,
+                originCountry
+        );
     }
 
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
@@ -1,26 +1,36 @@
-    package com.peliculas.peliculasapp.infrastructure.entities;
-    import com.peliculas.peliculasapp.domain.models.ProductionCountries;
-    import jakarta.persistence.Entity;
-    import jakarta.persistence.GeneratedValue;
-    import jakarta.persistence.GenerationType;
-    import jakarta.persistence.Id;
+package com.peliculas.peliculasapp.infrastructure.entities;
+import com.peliculas.peliculasapp.domain.models.ProductionCountries;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+@Entity
+public class ProductionCountriesEntity {
+     @Id
+     @GeneratedValue(strategy = GenerationType.IDENTITY)
+     private long id;
+     private String name;
+     private String iso31661;
+     public ProductionCountriesEntity() {}
 
-    @Entity
-    public class ProductionCountriesEntity {
+     public ProductionCountriesEntity(String name, String iso31661) {
+         this.name = name;
+         this.iso31661 = iso31661;
+     }
 
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private long id;
-        private String name;
-
-        private String iso31661;
 
     public static ProductionCountriesEntity fromDomainModel(ProductionCountries productionCountries) {
-        return new ProductionCountriesEntity();
+        return new ProductionCountriesEntity(
+                productionCountries.getName(),
+                productionCountries.getIso_3166_1()
+        );
     }
 
     public ProductionCountries toDomainModel() {
-        return new ProductionCountries();
+        return new ProductionCountries(
+                name,
+                iso31661
+        );
     }
 
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
@@ -18,6 +18,8 @@ public class TvSeriesRepositoryJpaImpl implements TvSeriesRepositoryPort {
     @Override
     public Optional<TvSeries> saveTvSeries(TvSeries tvSeries) {
         try {
+          long id = 1;
+          Optional<TvSeriesEntity> data = tvSeriesRepositoryJpa.findById(id);
           if (tvSeriesRepositoryJpa.existsById(tvSeries.getId())) {
               throw new TvSeriesAlreadyExistsException("Esta serie ya se encuentra guardada");
           }


### PR DESCRIPTION
Este pull request agrega la implementación de los métodos fromDomainModel y toDomainModel en las siguientes entidades:
- `ProductionCountriesEntity`
- `ProductionCompaniesEntity`
- `GenreEntity`
- `CreatedSeriesEntity`

También se agregó la anotación `@AllArgsConstructor` a las clases `ProductionCompany`, `ProductionCountries`, `Genre` y `CreatedSeries` para simplificar la inicialización de objetos.

Estos cambios permiten una mejor integración con el dominio de la aplicación y facilitan la conversión entre los modelos de dominio y las entidades de persistencia.