### PR TITLE
feat: Configurar conexión a Redis en RedisConfig

### DIFF
--- a/peliculas-app/pom.xml
+++ b/peliculas-app/pom.xml
@@ -34,6 +34,17 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>redis.clients</groupId>
+			<artifactId>jedis</artifactId>
+			<version>4.2.1</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
 			<version>3.1.1</version>

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
@@ -1,7 +1,6 @@
 package com.peliculas.peliculasapp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class PeliculasAppApplication {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/RedisConfig.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.peliculas.peliculasapp.application.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public JedisConnectionFactory jedisConnectionFactory() {
+        JedisConnectionFactory factory = new JedisConnectionFactory();
+        factory.setHostName("172.24.0.2");
+        factory.setPort(6379);
+        return factory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> jedis(JedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(jedisConnectionFactory());
+        return template;
+    }
+}

--- a/peliculas-app/src/main/resources/application.properties
+++ b/peliculas-app/src/main/resources/application.properties
@@ -1,4 +1,5 @@
-spring.datasource.url=jdbc:mysql://172.24.0.2:3307/moviedb
+# MySQL
+spring.datasource.url=jdbc:mysql://172.24.0.3:3307/moviedb
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.username=appmovie
@@ -6,3 +7,7 @@ spring.datasource.password=appmovie
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.initialization-mode=always
 spring.datasource.platform=mysql
+
+# Redis
+spring.redis.host=172.24.0.2
+spring.redis.port=6379


### PR DESCRIPTION
Descripción de cambios:

- Se agregó la configuración para establecer la conexión a Redis en la clase `RedisConfig`.
- Se definió un bean `JedisConnectionFactory` con la dirección IP y el puerto de la instancia de Redis.
- Se configuró un bean RedisTemplate para la interacción con Redis.
