### PR TITLE
apply solid

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/PeliculasAppApplication.java
@@ -1,8 +1,10 @@
 package com.peliculas.peliculasapp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class PeliculasAppApplication {
 
 	public static void main(String[] args) {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Genre.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Genre.java
@@ -2,11 +2,12 @@ package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class Genre {
+public class Genre implements Serializable {
 
     private String name;
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
@@ -1,5 +1,7 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.Data;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -48,4 +50,27 @@ public class Movie {
         this.poster_path = posterPath;
         this.release_date = releaseDate;
     }
+
+    public static Movie ofTesting() {
+        long id = 1;
+        String overview = "Descripcion de la pelicula";
+        String status = "Estado de la pelcula";
+        List<ProductionCompany> productionCompanies = new ArrayList<>();
+
+        List<Genre> genres = new ArrayList<>();
+
+        List<ProductionCountries> productionCountries = new ArrayList<>();
+
+        String title = "ttulo de la pelicula";
+        float voteAverage = 4.5f;
+        float voteCount = 1000;
+        long revenue = 1000000;
+        int budget = 500000;
+        String posterPath = "/poster.jpg";
+        float popularity = 7.8f;
+        String releaseDate = "2024-03-18";
+
+        return new Movie(id, overview, status, productionCompanies, genres, productionCountries, title, voteAverage, voteCount, revenue, budget, popularity, posterPath, releaseDate);
+    }
+
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCompany.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCompany.java
@@ -1,10 +1,14 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
-public class ProductionCompany {
+@NoArgsConstructor
+public class ProductionCompany implements Serializable {
 
     private String name;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
@@ -2,9 +2,11 @@ package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.io.Serializable;
+
 @Data
 @AllArgsConstructor
-public class ProductionCountries {
+public class ProductionCountries implements Serializable {
     private String name;
     private String iso_3166_1;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/dto/MovieInfoDTO.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/dto/MovieInfoDTO.java
@@ -3,10 +3,11 @@ import com.peliculas.peliculasapp.domain.models.Genre;
 import com.peliculas.peliculasapp.domain.models.ProductionCompany;
 import com.peliculas.peliculasapp.domain.models.ProductionCountries;
 import lombok.Data;
+import java.io.Serializable;
 import java.util.List;
 
 @Data
-public class MovieInfoDTO {
+public class MovieInfoDTO implements Serializable {
     private String title;
     private String homepage;
     private String overview;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/common/SuccessResponse.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/common/SuccessResponse.java
@@ -1,17 +1,13 @@
 package com.peliculas.peliculasapp.infrastructure.common;
-import com.peliculas.peliculasapp.domain.models.Movie;
+import lombok.Getter;
+import lombok.Setter;
+import java.io.Serializable;
 
-public class SuccessResponse {
+@Getter
+@Setter
+public class SuccessResponse implements Serializable {
     private int status;
     private String message;
-
-    public Object getMovie() {
-        return movie;
-    }
-
-    public void setMovie(Object movie) {
-        this.movie = movie;
-    }
 
     private Object movie;
 
@@ -19,21 +15,5 @@ public class SuccessResponse {
         this.status = status;
         this.message = message;
         this.movie = movie;
-    }
-
-    public int getStatus() {
-        return status;
-    }
-
-    public void setStatus(int status) {
-        this.status = status;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
     }
 }

--- a/peliculas-app/src/test/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveMovieInfoUseCaseImplTest.java
+++ b/peliculas-app/src/test/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveMovieInfoUseCaseImplTest.java
@@ -1,0 +1,112 @@
+package com.peliculas.peliculasapp.application.usecases;
+
+import com.peliculas.peliculasapp.application.ports.in.GetAndSaveMovieInfoUseCase;
+import com.peliculas.peliculasapp.application.ports.out.MovieRepositoryPort;
+import com.peliculas.peliculasapp.domain.models.Genre;
+import com.peliculas.peliculasapp.domain.models.Movie;
+import com.peliculas.peliculasapp.domain.models.ProductionCompany;
+import com.peliculas.peliculasapp.domain.models.ProductionCountries;
+import com.peliculas.peliculasapp.dto.MovieDTO;
+import com.peliculas.peliculasapp.dto.MovieInfoDTO;
+import com.peliculas.peliculasapp.infrastructure.adapters.MovieDetailsAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GetAndSaveMovieInfoUseCaseImplTest {
+    private MovieDetailsAdapter movieDetailsAdapter;
+    private MovieRepositoryPort movieRepository;
+    private ModelMapper modelMapper;
+    private RedisTemplate<String, Object> redisTemplate;
+    private GetAndSaveMovieInfoUseCase service;
+    private ValueOperations<String, Object> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        movieDetailsAdapter = Mockito.mock(MovieDetailsAdapter.class);
+        movieRepository = Mockito.mock(MovieRepositoryPort.class);
+        modelMapper = Mockito.mock(ModelMapper.class);
+        redisTemplate = Mockito.mock(RedisTemplate.class);
+
+        service = new GetAndSaveMovieInfoUseCaseImpl(
+                movieDetailsAdapter,
+                movieRepository,
+                modelMapper,
+                redisTemplate
+        );
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void testGetMovieByIdFromDatabase() {
+        // Arrange
+        long movieId = 123;
+        MovieInfoDTO expectedMovieInfoDTO = createSampleMovieInfoDTO();
+        Optional<Movie> optionalMovie = Optional.of(Movie.ofTesting()); // Mock your Optional<Movie> here
+
+        when(valueOperations.get(anyString())).thenReturn(null);
+        when(movieRepository.getMovieById(anyLong())).thenReturn(optionalMovie);
+        when(modelMapper.map(optionalMovie, MovieInfoDTO.class)).thenReturn(expectedMovieInfoDTO);
+
+        // Act
+        MovieInfoDTO result = service.getMovieById(movieId);
+
+        // Assert
+        assertEquals(expectedMovieInfoDTO, result);
+        verify(valueOperations, times(1)).get("movie:" + movieId);
+        verify(valueOperations, times(1)).set("movie:" + movieId, expectedMovieInfoDTO);
+        verify(movieRepository, times(1)).getMovieById(movieId);
+        verify(modelMapper, times(1)).map(optionalMovie, MovieInfoDTO.class);
+    }
+
+    private MovieInfoDTO createSampleMovieInfoDTO() {
+        MovieInfoDTO movieInfoDTO = new MovieInfoDTO();
+        movieInfoDTO.setTitle("Inception");
+        movieInfoDTO.setHomepage("https://www.warnerbros.com/movies/inception/");
+        movieInfoDTO.setOverview("Inception is a 2010 science fiction action film written and directed by Christopher Nolan, who also produced the film with Emma Thomas, his wife.");
+        movieInfoDTO.setRelease_date("2010-07-16");
+        movieInfoDTO.setPopularity(42.96f);
+        movieInfoDTO.setStatus("Released");
+
+        List<ProductionCompany> productionCompanies = new ArrayList<>();
+        ProductionCompany productionCompany = new ProductionCompany();
+        productionCompany.setName("Warner Bros. Pictures");
+        productionCompanies.add(productionCompany);
+        movieInfoDTO.setProduction_companies(productionCompanies);
+
+        List<ProductionCountries> productionCountries = new ArrayList<>();
+        ProductionCountries productionCountry = new ProductionCountries("dad", "23");
+        productionCountry.setName("United States of America");
+        productionCountries.add(productionCountry);
+        movieInfoDTO.setProduction_countries(productionCountries);
+
+        List<Genre> genres = new ArrayList<>();
+        Genre genre = new Genre();
+        genre.setName("Action");
+        genres.add(genre);
+        movieInfoDTO.setGenres(genres);
+
+        movieInfoDTO.setVote_average(8.8f);
+        movieInfoDTO.setVote_count(29390);
+        movieInfoDTO.setRevenue(829000000);
+        movieInfoDTO.setBudget(160000000);
+        movieInfoDTO.setPoster_path("/poster.jpg");
+
+        return movieInfoDTO;
+    }
+}


### PR DESCRIPTION
Refactorización: División del método principal en tres métodos más pequeños

Este PR introduce una refactorización en la clase `GetAndSaveMovieInfoUseCaseImpl `para mejorar su mantenibilidad y claridad. Se ha dividido el método principal en tres métodos más pequeños con responsabilidades específicas:

1. `getAndSaveMovieInfo`: Se encarga de obtener y guardar la información de la película.
2. `getMovieFromCache`: Se encarga de recuperar la película desde la caché.
3. `getMovieFromDatabase`: Se encarga de recuperar la película desde la base de datos.

Estos cambios simplifican el código y mejoran su legibilidad al separar las responsabilidades en métodos más pequeños y cohesivos.

Los cambios se implementaron en la clase `GetAndSaveMovieInfoUseCaseImpl `y se probaron localmente para garantizar su correcto funcionamiento.

Completar los tests!!!