### PR TITLE
Implementar caché para series de televisión y refactorización de GetAndSaveTvSeriesInfoUseCaseImpl

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/RedisConfig.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/config/RedisConfig.java
@@ -3,6 +3,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 @Configuration
 public class RedisConfig {
@@ -19,5 +20,10 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(jedisConnectionFactory());
         return template;
+    }
+
+    @Bean
+    public ValueOperations<String, Object> valueOperations(RedisTemplate<String, Object> redisTemplate) {
+        return redisTemplate.opsForValue();
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieRepositoryPort.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieRepositoryPort.java
@@ -4,6 +4,5 @@ import java.util.Optional;
 
 public interface MovieRepositoryPort {
     Optional<Movie> saveMovie(Movie movie);
-    
     Optional<Movie> getMovieById(long id);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/TvSeriesRepositoryPort.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/TvSeriesRepositoryPort.java
@@ -4,6 +4,6 @@ import java.util.Optional;
 
 public interface TvSeriesRepositoryPort {
     Optional<TvSeries> saveTvSeries(TvSeries series);
-
+    Optional<TvSeries> getTvSeriesById(long TvSeriesId);
     Optional<TvSeries> getTvSeriesInfo(long tvSeriesId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveMovieInfoUseCaseImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveMovieInfoUseCaseImpl.java
@@ -50,12 +50,12 @@ public class GetAndSaveMovieInfoUseCaseImpl implements GetAndSaveMovieInfoUseCas
 
     private MovieInfoDTO getMovieFromCache(long movieId) {
         System.out.println("Intentando obtener película desde la caché...");
-        return (MovieInfoDTO) valueOperations.get("movie:" + movieId); // Utiliza valueOperations aquí
+        return (MovieInfoDTO) valueOperations.get("movie:" + movieId);
     }
 
     private void storeMovieInCache(long movieId, MovieInfoDTO movieInfoDTO) {
         System.out.println("Guardando película en la caché...");
-        valueOperations.set("movie:" + movieId, movieInfoDTO, Duration.ofMinutes(1)); // Utiliza valueOperations aquí
+        valueOperations.set("movie:" + movieId, movieInfoDTO, Duration.ofMinutes(1));
     }
 
     private MovieInfoDTO getMovieFromDatabase(long movieId) {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveTvSeriesInfoUseCaseImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveTvSeriesInfoUseCaseImpl.java
@@ -6,8 +6,8 @@ import com.peliculas.peliculasapp.dto.TvSeriesDTO;
 import com.peliculas.peliculasapp.dto.TvSeriesInfoDTO;
 import com.peliculas.peliculasapp.infrastructure.adapters.SeriesDetailsAdapter;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
-
 import java.util.Optional;
 
 @Service
@@ -15,14 +15,17 @@ public class GetAndSaveTvSeriesInfoUseCaseImpl implements GetAndSaveTvSeriesInfo
     private final TvSeriesRepositoryPort tvSeriesRepositoryPort;
     private final SeriesDetailsAdapter seriesDetailsAdapter;
     private final ModelMapper modelMapper;
+    private final ValueOperations<String, Object> valueOperations;
 
     public GetAndSaveTvSeriesInfoUseCaseImpl(TvSeriesRepositoryPort tvSeriesRepositoryPort,
                                              SeriesDetailsAdapter seriesDetailsAdapter,
-                                             ModelMapper modelMapper)
+                                             ModelMapper modelMapper,
+                                             ValueOperations<String, Object> valueOperations)
     {
         this.tvSeriesRepositoryPort = tvSeriesRepositoryPort;
         this.seriesDetailsAdapter = seriesDetailsAdapter;
         this.modelMapper = modelMapper;
+        this.valueOperations = valueOperations;
     }
     @Override
     public TvSeriesDTO getAndSaveTvSeriesInfo(long tvSeriesId) {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/CreatedSeries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/CreatedSeries.java
@@ -1,10 +1,11 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
-public class CreatedSeries {
+public class CreatedSeries implements Serializable {
 
     private String name;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/CreatedSeries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/CreatedSeries.java
@@ -1,10 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class CreatedSeries implements Serializable {
 
     private String name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
@@ -1,10 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class LastEpisode implements Serializable {
     private int id;
     private String name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
@@ -1,10 +1,11 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
-public class LastEpisode {
+public class LastEpisode implements Serializable {
     private int id;
     private String name;
     private String overview;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Networks.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Networks.java
@@ -1,10 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class Networks implements Serializable {
     private String logo_path;
     private String name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Networks.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Networks.java
@@ -1,10 +1,11 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
-public class Networks {
+public class Networks implements Serializable {
     private String logo_path;
     private String name;
     private String origin_country;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/NextEpisode.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/NextEpisode.java
@@ -2,11 +2,12 @@ package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class NextEpisode {
+public class NextEpisode implements Serializable {
     private int id;
     private String name;
     private String overview;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/ProductionCountries.java
@@ -1,11 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class ProductionCountries implements Serializable {
     private String name;
     private String iso_3166_1;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Seasons.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Seasons.java
@@ -1,10 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class Seasons implements Serializable {
     private String air_date;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Seasons.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Seasons.java
@@ -1,10 +1,11 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
-public class Seasons {
+public class Seasons implements Serializable {
     private String air_date;
 
     private int episode_count;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/SpokenLanguages.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/SpokenLanguages.java
@@ -1,10 +1,11 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
-public class SpokenLanguages {
+public class SpokenLanguages implements Serializable {
     private String english_name;
     private String iso_639_1;
     private String name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/SpokenLanguages.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/SpokenLanguages.java
@@ -1,10 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class SpokenLanguages implements Serializable {
     private String english_name;
     private String iso_639_1;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/TvSeries.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/TvSeries.java
@@ -1,8 +1,13 @@
 package com.peliculas.peliculasapp.domain.models;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class TvSeries {
     private long id;
     private String backdrop_path;
@@ -32,36 +37,4 @@ public class TvSeries {
     private String tagline;
     private float vote_average;
     private int vote_count;
-
-
-    public TvSeries(long id, String backdrop_path, List<CreatedSeries> created_by, String first_air_date, List<Genre> genres, String homepage, boolean in_production, String last_air_date, LastEpisode last_episode_to_air, String name, NextEpisode next_episode_to_air, List<Networks> networks, int number_of_episodes, int number_of_seasons, List<String> origin_country, String original_language, String original_name, String overview, float popularity, String poster_path, List<ProductionCompany> production_companies, List<ProductionCountries> production_countries, List<Seasons> seasons, List<SpokenLanguages> spoken_languages, String status, String tagline, float vote_average, int vote_count) {
-        this.id = id;
-        this.backdrop_path = backdrop_path;
-        this.created_by = created_by;
-        this.first_air_date = first_air_date;
-        this.genres = genres;
-        this.homepage = homepage;
-        this.in_production = in_production;
-        this.last_air_date = last_air_date;
-        this.last_episode_to_air = last_episode_to_air;
-        this.name = name;
-        this.next_episode_to_air = next_episode_to_air;
-        this.networks = networks;
-        this.number_of_episodes = number_of_episodes;
-        this.number_of_seasons = number_of_seasons;
-        this.origin_country = origin_country;
-        this.original_language = original_language;
-        this.original_name = original_name;
-        this.overview = overview;
-        this.popularity = popularity;
-        this.poster_path = poster_path;
-        this.production_companies = production_companies;
-        this.production_countries = production_countries;
-        this.seasons = seasons;
-        this.spoken_languages = spoken_languages;
-        this.status = status;
-        this.tagline = tagline;
-        this.vote_average = vote_average;
-        this.vote_count = vote_count;
-    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/dto/TvSeriesInfoDTO.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/dto/TvSeriesInfoDTO.java
@@ -1,11 +1,11 @@
 package com.peliculas.peliculasapp.dto;
 import com.peliculas.peliculasapp.domain.models.*;
 import lombok.Data;
-
+import java.io.Serializable;
 import java.util.List;
 
 @Data
-public class TvSeriesInfoDTO {
+public class TvSeriesInfoDTO implements Serializable {
     private String name;
     private String poster_path;
     private String original_name;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/TvSeriesRepositoryJpaImpl.java
@@ -33,6 +33,12 @@ public class TvSeriesRepositoryJpaImpl implements TvSeriesRepositoryPort {
     @Override
     public Optional<TvSeries> getTvSeriesInfo(long tvSeriesId) {
         Optional<TvSeriesEntity> tvSeriesEntity = tvSeriesRepositoryJpa.findById(tvSeriesId);
-        return tvSeriesEntity.orElseThrow(() -> new TvSeriesNotFoundException("Serie con encontrada con el ID: " + tvSeriesId)).toDomainModel();
+        return tvSeriesEntity.orElseThrow(() -> new TvSeriesNotFoundException("Serie no encontrada con el ID: " + tvSeriesId)).toDomainModel();
+    }
+
+    @Override
+    public Optional<TvSeries> getTvSeriesById(long tvSeriesId) {
+        Optional<TvSeriesEntity> tvSeries = tvSeriesRepositoryJpa.findById(tvSeriesId);
+        return tvSeries.orElseThrow(() -> new TvSeriesNotFoundException("Serie no encontrada con el ID: " + tvSeriesId)).toDomainModel();
     }
 }

--- a/peliculas-app/src/test/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveMovieInfoUseCaseImplTest.java
+++ b/peliculas-app/src/test/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveMovieInfoUseCaseImplTest.java
@@ -48,7 +48,8 @@ class GetAndSaveMovieInfoUseCaseImplTest {
                 valueOperations
         );
     }
-    @Test void testGetMovieByIdFromCache() {
+    @Test
+    void testGetMovieByIdFromCache() {
         // Arrange
         long movieId = 1011985;
         MovieInfoDTO expectedMovieInfoDTO = createSampleMovieInfoDTO();

--- a/peliculas-app/src/test/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveTvSeriesInfoUseCaseImplTest.java
+++ b/peliculas-app/src/test/java/com/peliculas/peliculasapp/application/usecases/GetAndSaveTvSeriesInfoUseCaseImplTest.java
@@ -1,0 +1,296 @@
+package com.peliculas.peliculasapp.application.usecases;
+import com.peliculas.peliculasapp.application.ports.in.GetAndSaveMovieInfoUseCase;
+import com.peliculas.peliculasapp.application.ports.in.GetAndSaveTvSeriesInfoUseCase;
+import com.peliculas.peliculasapp.application.ports.out.MovieRepositoryPort;
+import com.peliculas.peliculasapp.application.ports.out.TvSeriesRepositoryPort;
+import com.peliculas.peliculasapp.domain.models.*;
+import com.peliculas.peliculasapp.dto.TvSeriesDTO;
+import com.peliculas.peliculasapp.dto.TvSeriesInfoDTO;
+import com.peliculas.peliculasapp.infrastructure.adapters.MovieDetailsAdapter;
+import com.peliculas.peliculasapp.infrastructure.adapters.SeriesDetailsAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GetAndSaveTvSeriesInfoUseCaseImplTest {
+
+    private TvSeriesRepositoryPort tvSeriesRepositoryPort;
+    private SeriesDetailsAdapter seriesDetailsAdapter;
+    private ModelMapper modelMapper;
+    private ValueOperations<String, Object> valueOperations;
+    private RedisTemplate<String, Object> redisTemplate;
+    private GetAndSaveTvSeriesInfoUseCase service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        tvSeriesRepositoryPort = Mockito.mock(TvSeriesRepositoryPort.class);
+        seriesDetailsAdapter = Mockito.mock(SeriesDetailsAdapter.class);
+        modelMapper = Mockito.mock(ModelMapper.class);
+        redisTemplate = Mockito.mock(RedisTemplate.class);
+        valueOperations = Mockito.mock(ValueOperations.class);
+
+        Mockito.when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        service = new GetAndSaveTvSeriesInfoUseCaseImpl(
+                tvSeriesRepositoryPort,
+                seriesDetailsAdapter,
+                modelMapper,
+                valueOperations
+        );
+    }
+
+    @Test
+    void testGetTvSeriesByIdFromCache() {
+        // arange
+        long tvSeriesId = 5;
+        TvSeriesInfoDTO expectedTvSeriesInfoDTO = createSampleTvSeriesInfoDTO();
+
+        Mockito.when(valueOperations.get("series:" + tvSeriesId)).thenReturn(expectedTvSeriesInfoDTO);
+
+        // act
+        TvSeriesInfoDTO result = service.getTvSeriesInfoById(tvSeriesId);
+
+        // assert
+        assertEquals(expectedTvSeriesInfoDTO, result);
+        verify(valueOperations, times(1)).get("series:" + tvSeriesId);
+        verify(tvSeriesRepositoryPort, never()).getTvSeriesById(tvSeriesId);
+    }
+
+    @Test
+    void testGetAndSaveTvSeriesInfo() {
+
+        // arrange
+        long tvSeriesId = 2;
+        TvSeriesDTO expectedTvSeriesDTO = new TvSeriesDTO();
+        expectedTvSeriesDTO.setName("Breaking bad");
+        expectedTvSeriesDTO.setOverview("El pelado mas capo");
+        expectedTvSeriesDTO.setNumber_of_episodes(5);
+        expectedTvSeriesDTO.setNumber_of_seasons(7);
+        expectedTvSeriesDTO.setPopularity(2323245);
+
+        TvSeries series = ofTesting();
+        Mockito.when(seriesDetailsAdapter.getTvSeriesInfoById(tvSeriesId)).thenReturn(series);
+        Mockito.when(modelMapper.map(series, TvSeriesDTO.class)).thenReturn(expectedTvSeriesDTO);
+
+        // act
+        TvSeriesDTO result = service.getAndSaveTvSeriesInfo(tvSeriesId);
+
+        // assert
+        assertEquals(expectedTvSeriesDTO, result);
+        verify(tvSeriesRepositoryPort, times(1)).saveTvSeries(series);
+
+    }
+
+    @Test
+    void testGetTvSeriesByIdFromDatabase() {
+
+        // arrange
+        long tvSeriesId = 6;
+        TvSeriesInfoDTO expectedTvSeriesInfoDTO = createSampleTvSeriesInfoDTO();
+
+        Optional<TvSeries> series = Optional.of(ofTesting());
+        Mockito.when(tvSeriesRepositoryPort.getTvSeriesById(tvSeriesId)).thenReturn(series);
+        Mockito.when(modelMapper.map(series, TvSeriesInfoDTO.class)).thenReturn(expectedTvSeriesInfoDTO);
+
+        // act
+        TvSeriesInfoDTO result = service.getTvSeriesInfoById(tvSeriesId);
+
+        // assert
+        assertNotNull(result);
+        assertEquals(expectedTvSeriesInfoDTO, result);
+        verify(redisTemplate, atMost(1)).opsForValue();
+        verify(tvSeriesRepositoryPort, times(1)).getTvSeriesById(tvSeriesId);
+        verify(valueOperations, times(1)).set(eq("series:" + tvSeriesId), eq(expectedTvSeriesInfoDTO), eq(Duration.ofMinutes(1)));
+    }
+
+    @Test
+    void testGetTvSeriesByIdFromDatabaseWhenMovieDoesNotExist() {
+        // arrange
+        long tvSeriesId = 6;
+
+        Optional<TvSeries> series = Optional.empty();
+        when(tvSeriesRepositoryPort.getTvSeriesById(tvSeriesId)).thenReturn(series);
+
+        // act
+        TvSeriesInfoDTO result = service.getTvSeriesInfoById(tvSeriesId);
+
+        // assert
+        assertNull(result);
+        verify(redisTemplate, never()).opsForValue();
+        verify(tvSeriesRepositoryPort, times(1)).getTvSeriesById(tvSeriesId);
+    }
+
+    private TvSeries ofTesting() {
+        TvSeries tvSeries = new TvSeries();
+
+        tvSeries.setId(12);
+        tvSeries.setName("Breaking Bad");
+        tvSeries.setBackdrop_path("/zzWGRw277MNoCs3zhyG3YmYQsXv.jpg");
+        tvSeries.setFirst_air_date("2008-01-20");
+        tvSeries.setHomepage("https://www.amc.com/shows/breaking-bad");
+        tvSeries.setIn_production(false);
+        tvSeries.setLast_air_date("2013-09-29");
+        tvSeries.setName("Breaking Bad");
+        tvSeries.setNumber_of_episodes(62);
+        tvSeries.setNumber_of_seasons(5);
+        tvSeries.setOriginal_language("en");
+        tvSeries.setOriginal_name("Breaking Bad");
+        tvSeries.setOverview("Breaking Bad follows protagonist Walter White, a chemistry teacher who lives in New Mexico with his wife and teenage son who has cerebral palsy.");
+        tvSeries.setPopularity(135.328f);
+        tvSeries.setPoster_path("/zzWGRw277MNoCs3zhyG3YmYQsXv.jpg");
+        tvSeries.setStatus("Ended");
+        tvSeries.setTagline("All Hail the King");
+        tvSeries.setVote_average(9.3f);
+        tvSeries.setVote_count(14102);
+
+        List<CreatedSeries> createdSeriesList = new ArrayList<>();
+        CreatedSeries creator = new CreatedSeries();
+        creator.setName("Vince Gilligan");
+        createdSeriesList.add(creator);
+        tvSeries.setCreated_by(createdSeriesList);
+
+        List<Genre> genreList = new ArrayList<>();
+        Genre genre = new Genre();
+        genre.setName("Drama");
+        genreList.add(genre);
+        tvSeries.setGenres(genreList);
+
+        LastEpisode lastEpisode = new LastEpisode();
+        lastEpisode.setEpisode_number(16);
+        lastEpisode.setName("Felina");
+        lastEpisode.setAir_date("2013-09-29");
+        tvSeries.setLast_episode_to_air(lastEpisode);
+
+        List<Networks> networksList = new ArrayList<>();
+        Networks network = new Networks();
+        network.setName("AMC");
+        networksList.add(network);
+        tvSeries.setNetworks(networksList);
+
+        List<String> originCountryList = new ArrayList<>();
+        originCountryList.add("US");
+        tvSeries.setOrigin_country(originCountryList);
+
+        List<Seasons> seasonsList = new ArrayList<>();
+        Seasons season = new Seasons();
+        season.setSeason_number(1);
+        seasonsList.add(season);
+        tvSeries.setSeasons(seasonsList);
+
+        List<ProductionCompany> productionCompanyList = new ArrayList<>();
+        ProductionCompany productionCompany = new ProductionCompany();
+        productionCompany.setName("Sony Pictures Television");
+        productionCompanyList.add(productionCompany);
+        tvSeries.setProduction_companies(productionCompanyList);
+
+        List<ProductionCountries> productionCountriesList = new ArrayList<>();
+        ProductionCountries productionCountry = new ProductionCountries();
+        productionCountry.setName("United States of America");
+        productionCountriesList.add(productionCountry);
+        tvSeries.setProduction_countries(productionCountriesList);
+
+        List<SpokenLanguages> spokenLanguagesList = new ArrayList<>();
+        SpokenLanguages spokenLanguage = new SpokenLanguages();
+        spokenLanguage.setName("English");
+        spokenLanguagesList.add(spokenLanguage);
+        tvSeries.setSpoken_languages(spokenLanguagesList);
+        return tvSeries;
+    }
+
+    private TvSeriesInfoDTO createSampleTvSeriesInfoDTO() {
+        TvSeriesInfoDTO tvSeriesInfoDTO = new TvSeriesInfoDTO();
+
+        tvSeriesInfoDTO.setName("Breaking Bad");
+        tvSeriesInfoDTO.setPoster_path("/zzWGRw277MNoCs3zhyG3YmYQsXv.jpg");
+        tvSeriesInfoDTO.setOriginal_name("Breaking Bad");
+        tvSeriesInfoDTO.setBackdrop_path("/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg");
+        tvSeriesInfoDTO.setOverview("Breaking Bad follows protagonist Walter White, a chemistry teacher who lives in New Mexico with his wife and teenage son who has cerebral palsy.");
+        tvSeriesInfoDTO.setIn_production(false);
+        tvSeriesInfoDTO.setHomepage("https://www.amc.com/shows/breaking-bad");
+        tvSeriesInfoDTO.setOriginal_language("en");
+        tvSeriesInfoDTO.setPopularity(135.328f);
+        tvSeriesInfoDTO.setStatus("Ended");
+        tvSeriesInfoDTO.setTagline("All Hail the King");
+        tvSeriesInfoDTO.setVote_average(9.3f);
+        tvSeriesInfoDTO.setVote_count(14102);
+        tvSeriesInfoDTO.setLast_air_date("2013-09-29");
+        tvSeriesInfoDTO.setNumber_of_episodes(62);
+        tvSeriesInfoDTO.setNumber_of_seasons(5);
+
+        // Set sample data for created_by list
+        List<CreatedSeries> createdSeriesList = new ArrayList<>();
+        CreatedSeries creator = new CreatedSeries();
+        creator.setName("Vince Gilligan");
+        createdSeriesList.add(creator);
+        tvSeriesInfoDTO.setCreated_by(createdSeriesList);
+
+        // Set sample data for genres list
+        List<Genre> genreList = new ArrayList<>();
+        Genre genre = new Genre();
+        genre.setName("Drama");
+        genreList.add(genre);
+        tvSeriesInfoDTO.setGenres(genreList);
+
+        // Set sample data for last_episode_to_air
+        LastEpisode lastEpisode = new LastEpisode();
+        lastEpisode.setEpisode_number(16);
+        lastEpisode.setName("Felina");
+        lastEpisode.setAir_date("2013-09-29");
+        tvSeriesInfoDTO.setLast_episode_to_air(lastEpisode);
+
+        // Set sample data for networks list
+        List<Networks> networksList = new ArrayList<>();
+        Networks network = new Networks();
+        network.setName("AMC");
+        networksList.add(network);
+        tvSeriesInfoDTO.setNetworks(networksList);
+
+        // Set sample data for origin_country list
+        List<String> originCountryList = new ArrayList<>();
+        originCountryList.add("US");
+        tvSeriesInfoDTO.setOrigin_country(originCountryList);
+
+        // Set sample data for seasons list
+        List<Seasons> seasonsList = new ArrayList<>();
+        Seasons season = new Seasons();
+        season.setSeason_number(1);
+        seasonsList.add(season);
+        tvSeriesInfoDTO.setSeasons(seasonsList);
+
+        // Set sample data for production_companies list
+        List<ProductionCompany> productionCompanyList = new ArrayList<>();
+        ProductionCompany productionCompany = new ProductionCompany();
+        productionCompany.setName("Sony Pictures Television");
+        productionCompanyList.add(productionCompany);
+        tvSeriesInfoDTO.setProduction_companies(productionCompanyList);
+
+        // Set sample data for production_countries list
+        List<ProductionCountries> productionCountriesList = new ArrayList<>();
+        ProductionCountries productionCountry = new ProductionCountries();
+        productionCountry.setName("United States of America");
+        productionCountriesList.add(productionCountry);
+        tvSeriesInfoDTO.setProduction_countries(productionCountriesList);
+
+        // Set sample data for spoken_languages list
+        List<SpokenLanguages> spokenLanguagesList = new ArrayList<>();
+        SpokenLanguages spokenLanguage = new SpokenLanguages();
+        spokenLanguage.setName("English");
+        spokenLanguagesList.add(spokenLanguage);
+        tvSeriesInfoDTO.setSpoken_languages(spokenLanguagesList);
+
+        return tvSeriesInfoDTO;
+    }
+}


### PR DESCRIPTION
Descripción del PR:
Este PR introduce mejoras significativas en la clase `GetAndSaveTvSeriesInfoUseCaseImpl`, incluyendo la implementación de la funcionalidad de caché para mejorar el rendimiento al obtener información de series de televisión y una refactorización para cumplir con el principio de responsabilidad única (SRP).

Cambios Propuestos:

* Se ha añadido el método `getTvSeriesInfoById` para obtener información de una serie de televisión por su ID, implementando la lógica necesaria para buscar primero en la caché y luego en la base de datos si es necesario.
* Se han refactorizado partes de la clase `GetAndSaveTvSeriesInfoUseCaseImpl` para dividir la lógica en métodos más pequeños, mejorando la legibilidad y mantenibilidad del código.
* Se ha añadido un bean para `ValueOperations` con el propósito de utilizarlo en las operaciones de caché.
* Se han añadido nuevas pruebas unitarias para cubrir los escenarios del método `getTvSeriesInfoById`, asegurando una mayor cobertura de pruebas y la calidad del código.

Pruebas Realizadas:
* Se han añadido nuevas pruebas unitarias para cubrir los casos de uso del método `getTvSeriesInfoById`, verificando su comportamiento cuando se encuentra en caché y cuando se necesita buscar en la base de datos.