### PR TITLE
feat: Agregar mapeadores genéricos para varias entidades

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/incoming/EntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/incoming/EntityMapper.java
@@ -1,0 +1,6 @@
+package com.peliculas.peliculasapp.application.ports.incoming;
+
+public interface EntityMapper<E, D> {
+    D toDomainModel(E entity);
+    E toEntity(D model);
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/incoming/UserMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/incoming/UserMapper.java
@@ -1,8 +1,0 @@
-package com.peliculas.peliculasapp.application.ports.incoming;
-import com.peliculas.peliculasapp.domain.models.User;
-import com.peliculas.peliculasapp.infrastructure.entities.UserEntity;
-
-public interface UserMapper {
-    User toDomainModel(UserEntity userEntity);
-    UserEntity toEntity(User user);
-}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieReviewRepositoryPort.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieReviewRepositoryPort.java
@@ -1,11 +1,10 @@
 package com.peliculas.peliculasapp.application.ports.out;
-import com.peliculas.peliculasapp.domain.models.Review;
+import com.peliculas.peliculasapp.domain.models.MovieReview;
 import java.util.Optional;
 
 public interface MovieReviewRepositoryPort {
-    Optional<Review> createMovieReview(Review review);
-    Optional<Review> updateMovieReview(Review review);
-    Optional<Review> findReviewsByMovieId(long reviewId);
-
-    Optional<Review> deleteReviewById(long reviewId);
+    Optional<MovieReview> createMovieReview(MovieReview review);
+    Optional<MovieReview> updateMovieReview(MovieReview review);
+    Optional<MovieReview> findReviewsByMovieId(long reviewId);
+    Optional<MovieReview> deleteReviewById(long reviewId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/MovieReview.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/MovieReview.java
@@ -1,0 +1,13 @@
+package com.peliculas.peliculasapp.domain.models;
+import lombok.Data;
+import java.time.LocalDateTime;
+@Data
+public class MovieReview {
+    private long id;
+    private Movie movie;
+    private User user;
+    private String reviewText;
+    private int rating;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Review.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Review.java
@@ -1,5 +1,0 @@
-package com.peliculas.peliculasapp.domain.models;
-
-public class Review {
-    // TODO: implement
-}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/MovieReviewEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/MovieReviewEntity.java
@@ -1,0 +1,32 @@
+package com.peliculas.peliculasapp.infrastructure.entities;
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "movie_review")
+public class MovieReviewEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "movie_id")
+    private MovieEntity movie;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @Column(name = "review_text")
+    private String reviewText;
+    private int rating;
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieReviewRepository.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieReviewRepository.java
@@ -1,0 +1,10 @@
+package com.peliculas.peliculasapp.infrastructure.repositories;
+import com.peliculas.peliculasapp.infrastructure.entities.MovieReviewEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional
+public interface MovieReviewRepository extends JpaRepository<MovieReviewEntity, Long> {
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieReviewRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/MovieReviewRepositoryJpaImpl.java
@@ -1,30 +1,42 @@
 package com.peliculas.peliculasapp.infrastructure.repositories;
 import com.peliculas.peliculasapp.application.ports.out.MovieReviewRepositoryPort;
-import com.peliculas.peliculasapp.domain.models.Review;
-
+import com.peliculas.peliculasapp.domain.models.MovieReview;
+import com.peliculas.peliculasapp.infrastructure.entities.MovieReviewEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
+@Repository
 public class MovieReviewRepositoryJpaImpl implements MovieReviewRepositoryPort {
+    private final MovieReviewRepository movieReviewRepository;
+
+    @Autowired
+    public MovieReviewRepositoryJpaImpl(MovieReviewRepository movieReviewRepository)  {
+        this.movieReviewRepository = movieReviewRepository;
+    }
+
     @Override
-    public Optional<Review> createMovieReview(Review review) {
+    public Optional<MovieReview> createMovieReview(MovieReview movieReview) {
+        // TODO: Implement
+        Optional<MovieReviewEntity> existingMovie = movieReviewRepository.findById(movieReview.getId());
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<MovieReview> updateMovieReview(MovieReview review) {
         // TODO: Implement
         return Optional.empty();
     }
 
     @Override
-    public Optional<Review> updateMovieReview(Review review) {
+    public Optional<MovieReview> findReviewsByMovieId(long reviewId) {
         // TODO: Implement
         return Optional.empty();
     }
 
     @Override
-    public Optional<Review> findReviewsByMovieId(long reviewId) {
-        // TODO: Implement
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Review> deleteReviewById(long reviewId) {
+    public Optional<MovieReview> deleteReviewById(long reviewId) {
         // TODO: Implement
         return Optional.empty();
     }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/UserMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/UserMapper.java
@@ -1,12 +1,12 @@
 package com.peliculas.peliculasapp.infrastructure.repositories;
-import com.peliculas.peliculasapp.application.ports.incoming.UserMapper;
+import com.peliculas.peliculasapp.application.ports.incoming.EntityMapper;
 import com.peliculas.peliculasapp.domain.models.User;
 import com.peliculas.peliculasapp.infrastructure.entities.UserEntity;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UserMapperImpl implements UserMapper {
-    public UserMapperImpl() {}
+public class UserMapper implements EntityMapper<UserEntity, User> {
+    public UserMapper() {}
 
     @Override
     public User toDomainModel(UserEntity userEntity) {

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/UserRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/repositories/UserRepositoryJpaImpl.java
@@ -1,5 +1,4 @@
 package com.peliculas.peliculasapp.infrastructure.repositories;
-import com.peliculas.peliculasapp.application.ports.incoming.UserMapper;
 import com.peliculas.peliculasapp.application.ports.out.UserRepositoryPort;
 import com.peliculas.peliculasapp.domain.models.User;
 import com.peliculas.peliculasapp.infrastructure.entities.UserEntity;

--- a/peliculas-app/src/main/resources/application.properties
+++ b/peliculas-app/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # MySQL
-spring.datasource.url=jdbc:mysql://172.24.0.2:3307/moviedb
+spring.datasource.url=jdbc:mysql://172.24.0.3:3307/moviedb
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.username=appmovie


### PR DESCRIPTION
Descripción:
Este PR introduce una interfaz genérica para mapear entidades a modelos de dominio y viceversa. Esta abstracción permite reutilizar el código de mapeo para diferentes tipos de entidades y modelos de dominio en el proyecto.

Cambios realizados:
- Agregada la interfaz `EntityMapper<E, D>` para el mapeo genérico.
- Implementación de la interfaz para mapear `UserEntity` a `User` y viceversa en la clase `UserMapper`.
- Creacion del modelo `MovieReview`.

Detalles adicionales:
Este cambio busca mejorar la modularidad y mantenibilidad del código al reducir la duplicación y promover la reutilización de código para tareas de mapeo en el proyecto.
