### PR TITLE
Refactorización: Crear mappers y eliminar métodos fromDomainModel/toDomainModel

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/incoming/EntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/incoming/EntityMapper.java
@@ -1,6 +1,6 @@
 package com.peliculas.peliculasapp.application.ports.incoming;
 
 public interface EntityMapper<E, D> {
+    E toEntity(D domain);
     D toDomainModel(E entity);
-    E toEntity(D model);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
@@ -1,7 +1,5 @@
 package com.peliculas.peliculasapp.domain.models;
 import lombok.Data;
-
-import java.util.ArrayList;
 import java.util.List;
 
 @Data

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/GenreEntity.java
@@ -1,8 +1,11 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.Genre;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class GenreEntity {
 
     @Id
@@ -15,16 +18,5 @@ public class GenreEntity {
 
     public GenreEntity(String name) {
         this.name = name;
-    }
-
-    public static GenreEntity fromDomainModel(Genre genre) {
-        return new GenreEntity(
-                genre.getName()
-        );
-    }
-    public Genre toDomainModel() {
-        return new Genre(
-                name
-        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/MovieEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/MovieEntity.java
@@ -1,15 +1,8 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.Genre;
-import com.peliculas.peliculasapp.domain.models.Movie;
-import com.peliculas.peliculasapp.domain.models.ProductionCompany;
-import com.peliculas.peliculasapp.domain.models.ProductionCountries;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Entity
 @Setter
@@ -70,67 +63,5 @@ public class MovieEntity {
         this.popularity = popularity;
         this.posterPath = posterPath;
         this.releaseDate = releaseDate;
-    }
-
-    public static MovieEntity fromDomainModel(Movie movie) {
-        List<ProductionCountriesEntity> productionCountriesEntities = movie.getProduction_countries().stream()
-                .map(ProductionCountriesEntity::fromDomainModel)
-                .toList();
-
-        List<ProductionCompaniesEntity> productionCompanyEntities = movie.getProduction_companies().stream()
-                .map(ProductionCompaniesEntity::fromDomainModel)
-                .toList();
-
-        List<GenreEntity> genreEntities = movie.getGenres().stream()
-                .map(GenreEntity::fromDomainModel)
-                .toList();
-
-        return new MovieEntity(
-                movie.getId(),
-                movie.getOverview(),
-                movie.getStatus(),
-                productionCompanyEntities,
-                genreEntities,
-                productionCountriesEntities,
-                movie.getTitle(),
-                movie.getVote_average(),
-                movie.getVote_count(),
-                movie.getRevenue(),
-                movie.getBudget(),
-                movie.getPopularity(),
-                movie.getPoster_path(),
-                movie.getRelease_date()
-        );
-    }
-
-    public Optional<Movie> toDomainModel() {
-        List<ProductionCountries> productionCountries = this.productionCountries.stream()
-                .map(ProductionCountriesEntity::toDomainModel)
-                .collect(Collectors.toList());
-
-        List<ProductionCompany> productionCompanies = this.productionCompanies.stream()
-                .map(ProductionCompaniesEntity::toDomainModel)
-                .collect(Collectors.toList());
-
-        List<Genre> genreList = this.genres.stream()
-                .map(GenreEntity::toDomainModel)
-                .collect(Collectors.toList());
-
-        return Optional.of(new Movie(
-                movieId,
-                overview,
-                status,
-                productionCompanies,
-                genreList,
-                productionCountries,
-                title,
-                voteAverage,
-                voteCount,
-                revenue,
-                budget,
-                popularity,
-                posterPath,
-                releaseDate
-        ));
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCompaniesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCompaniesEntity.java
@@ -1,11 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.ProductionCompany;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class ProductionCompaniesEntity {
 
     @Id
@@ -20,27 +23,9 @@ public class ProductionCompaniesEntity {
 
     public ProductionCompaniesEntity() {}
 
-    private ProductionCompaniesEntity(String name, String logoPath, String originCountry) {
+    public ProductionCompaniesEntity(String name, String logoPath, String originCountry) {
         this.name = name;
         this.logoPath = logoPath;
         this.originCountry = originCountry;
     }
-
-
-    public static ProductionCompaniesEntity fromDomainModel(ProductionCompany productionCompany) {
-        return new ProductionCompaniesEntity(
-                productionCompany.getName(),
-                productionCompany.getLogo_path(),
-                productionCompany.getOrigin_country()
-        );
-    }
-
-    public ProductionCompany toDomainModel() {
-        return new ProductionCompany(
-                name,
-                logoPath,
-                originCountry
-        );
-    }
-
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/ProductionCountriesEntity.java
@@ -1,10 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.ProductionCountries;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
 @Entity
+@Getter
+@Setter
 public class ProductionCountriesEntity {
      @Id
      @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,20 +21,4 @@ public class ProductionCountriesEntity {
          this.name = name;
          this.iso31661 = iso31661;
      }
-
-
-    public static ProductionCountriesEntity fromDomainModel(ProductionCountries productionCountries) {
-        return new ProductionCountriesEntity(
-                productionCountries.getName(),
-                productionCountries.getIso_3166_1()
-        );
-    }
-
-    public ProductionCountries toDomainModel() {
-        return new ProductionCountries(
-                name,
-                iso31661
-        );
-    }
-
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/GenreEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/GenreEntityMapper.java
@@ -1,0 +1,21 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.Genre;
+import com.peliculas.peliculasapp.infrastructure.entities.GenreEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class GenreEntityMapper {
+    public List<GenreEntity> fromDomainModel(List<Genre> genres) {
+        return genres.stream()
+                .map(genre -> new GenreEntity(genre.getName()))
+                .collect(Collectors.toList());
+    }
+
+    public List<Genre> toDomainModel(List<GenreEntity> genres) {
+        return genres.stream()
+                .map(genre -> new Genre(genre.getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/MovieEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/MovieEntityMapper.java
@@ -1,5 +1,4 @@
 package com.peliculas.peliculasapp.infrastructure.mapper;
-import com.peliculas.peliculasapp.application.ports.incoming.EntityMapper;
 import com.peliculas.peliculasapp.domain.models.Genre;
 import com.peliculas.peliculasapp.domain.models.Movie;
 import com.peliculas.peliculasapp.domain.models.ProductionCompany;
@@ -8,72 +7,67 @@ import com.peliculas.peliculasapp.infrastructure.entities.GenreEntity;
 import com.peliculas.peliculasapp.infrastructure.entities.MovieEntity;
 import com.peliculas.peliculasapp.infrastructure.entities.ProductionCompaniesEntity;
 import com.peliculas.peliculasapp.infrastructure.entities.ProductionCountriesEntity;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class MovieEntityMapper implements EntityMapper<MovieEntity, Movie> {
+public class MovieEntityMapper {
+    private final ProductionCountriesEntityMapper productionCountriesEntityMapper;
+    private final ProductionCompaniesEntityMapper productionCompaniesEntityMapper;
+    private final GenreEntityMapper genreEntityMapper;
 
-    @Override
-    public Movie toDomainModel(MovieEntity entity) {
-        List<ProductionCountries> productionCountries = entity.getProductionCountries().stream()
-                .map(ProductionCountriesEntity::toDomainModel)
-                .toList();
+    @Autowired
+    public MovieEntityMapper(ProductionCountriesEntityMapper productionCountriesEntityMapper, ProductionCompaniesEntityMapper productionCompaniesEntityMapper, GenreEntityMapper genreEntityMapper) {
+        this.productionCountriesEntityMapper = productionCountriesEntityMapper;
+        this.productionCompaniesEntityMapper = productionCompaniesEntityMapper;
+        this.genreEntityMapper = genreEntityMapper;
+    }
 
-        List<ProductionCompany> productionCompanies = entity.getProductionCompanies().stream()
-                .map(ProductionCompaniesEntity::toDomainModel)
-                .toList();
+    public MovieEntity fromDomainModel(Movie movie) {
+        List<ProductionCountriesEntity> productionCountriesEntities = productionCountriesEntityMapper.fromDomainModel(movie.getProduction_countries());
+        List<ProductionCompaniesEntity> productionCompaniesEntities = productionCompaniesEntityMapper.fromDomainModel(movie.getProduction_companies());
+        List<GenreEntity> genreEntities = genreEntityMapper.fromDomainModel(movie.getGenres());
 
-        List<Genre> genres = entity.getGenres().stream()
-                .map(GenreEntity::toDomainModel)
-                .toList();
-        return new Movie(
-                entity.getMovieId(),
-                entity.getOverview(),
-                entity.getStatus(),
-                productionCompanies,
-                genres,
-                productionCountries,
-                entity.getTitle(),
-                entity.getVoteAverage(),
-                entity.getVoteCount(),
-                entity.getRevenue(),
-                entity.getBudget(),
-                entity.getPopularity(),
-                entity.getPosterPath(),
-                entity.getReleaseDate()
+        return new MovieEntity(
+                movie.getId(),
+                movie.getOverview(),
+                movie.getStatus(),
+                productionCompaniesEntities,
+                genreEntities,
+                productionCountriesEntities,
+                movie.getTitle(),
+                movie.getVote_average(),
+                movie.getVote_count(),
+                movie.getRevenue(),
+                movie.getBudget(),
+                movie.getPopularity(),
+                movie.getPoster_path(),
+                movie.getRelease_date()
         );
     }
 
-    @Override
-    public MovieEntity toEntity(Movie model) {
-        List<ProductionCountriesEntity> productionCountriesEntities = model.getProduction_countries().stream()
-                .map(ProductionCountriesEntity::fromDomainModel)
-                .toList();
+    public Movie toDomainModel(MovieEntity movieEntity) {
+        List<ProductionCountries> productionCountries = productionCountriesEntityMapper.toDomainModel(movieEntity.getProductionCountries());
+        List<ProductionCompany> productionCompanies = productionCompaniesEntityMapper.toDomainModel(movieEntity.getProductionCompanies());
+        List<Genre> genres = genreEntityMapper.toDomainModel(movieEntity.getGenres());
 
-        List<ProductionCompaniesEntity> productionCompanyEntities = model.getProduction_companies().stream()
-                .map(ProductionCompaniesEntity::fromDomainModel)
-                .toList();
 
-        List<GenreEntity> genreEntities = model.getGenres().stream()
-                .map(GenreEntity::fromDomainModel)
-                .toList();
-
-        return new MovieEntity(
-                model.getId(),
-                model.getOverview(),
-                model.getStatus(),
-                productionCompanyEntities,
-                genreEntities,
-                productionCountriesEntities,
-                model.getTitle(),
-                model.getVote_average(),
-                model.getVote_count(),
-                model.getRevenue(),
-                model.getBudget(),
-                model.getPopularity(),
-                model.getPoster_path(),
-                model.getRelease_date()
+        return new Movie(
+                movieEntity.getId(),
+                movieEntity.getOverview(),
+                movieEntity.getStatus(),
+                productionCompanies,
+                genres,
+                productionCountries,
+                movieEntity.getTitle(),
+                movieEntity.getVoteAverage(),
+                movieEntity.getVoteCount(),
+                movieEntity.getRevenue(),
+                movieEntity.getBudget(),
+                movieEntity.getPopularity(),
+                movieEntity.getPosterPath(),
+                movieEntity.getReleaseDate()
         );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ProductionCompaniesEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ProductionCompaniesEntityMapper.java
@@ -1,0 +1,21 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.ProductionCompany;
+import com.peliculas.peliculasapp.infrastructure.entities.ProductionCompaniesEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ProductionCompaniesEntityMapper {
+    public List<ProductionCompaniesEntity> fromDomainModel(List<ProductionCompany> companies) {
+        return companies.stream()
+                .map(productionCompany -> new ProductionCompaniesEntity(productionCompany.getName(), productionCompany.getLogo_path(), productionCompany.getOrigin_country()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ProductionCompany> toDomainModel(List<ProductionCompaniesEntity> companiesEntityList) {
+        return companiesEntityList.stream()
+                .map(productionCompany -> new ProductionCompany(productionCompany.getName(), productionCompany.getLogoPath(), productionCompany.getOriginCountry()))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ProductionCountriesEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ProductionCountriesEntityMapper.java
@@ -1,0 +1,23 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.ProductionCountries;
+import com.peliculas.peliculasapp.infrastructure.entities.ProductionCountriesEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ProductionCountriesEntityMapper {
+
+    public List<ProductionCountriesEntity> fromDomainModel(List<ProductionCountries> productionCountriesList) {
+        return productionCountriesList.stream()
+                .map(productionCountries -> new ProductionCountriesEntity(productionCountries.getName(), productionCountries.getIso_3166_1()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ProductionCountries> toDomainModel(List<ProductionCountriesEntity> productionCountriesEntityList) {
+        return productionCountriesEntityList.stream()
+                .map(productionCountriesEntity -> new ProductionCountries(productionCountriesEntity.getName(), productionCountriesEntity.getIso31661()))
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
Este PR introduce una refactorización en el código relacionado con la conversión entre objetos de dominio y entidades JPA. Los cambios incluyen la creación de mappers dedicados para manejar esta conversión, lo que elimina métodos `fromDomainModel`/`toDomainModel` en las clases de dominio y entidades jpa. Esto mejora la cohesión del código y sigue el principio de responsabilidad única (SRP).

Detalles de los cambios:
- Se han creado `ProductionCountriesEntityMapper`, `ProductionCompaniesEntityMapper` y `GenreEntityMapper` para manejar la conversión entre objetos de dominio y entidades.
- Se ha eliminado la lógica de mapeo de las clases de dominio y entidades(`ProductionCountries`, `ProductionCompanies`, `Genre`), lo que elimina la violación del SRP