### PR TITLE
Refactorización de TvSeriesRepositoryJpaImpl y corrección de error de longitud de columna

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
@@ -2,7 +2,6 @@ package com.peliculas.peliculasapp.domain.models;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import java.io.Serializable;
 
 @Data

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/LastEpisode.java
@@ -21,6 +21,4 @@ public class LastEpisode implements Serializable {
     private int season_number;
     private int show_id;
     private String still_path;
-
-
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/CreatedSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/CreatedSeriesEntity.java
@@ -1,11 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.CreatedSeries;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class CreatedSeriesEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,21 +24,4 @@ public class CreatedSeriesEntity {
         this.gender = gender;
         this.profilePath = profilePath;
     }
-
-    public static CreatedSeriesEntity fromDomainModel(CreatedSeries createdSeries) {
-        return new CreatedSeriesEntity(
-                createdSeries.getName(),
-                createdSeries.getGender(),
-                createdSeries.getProfile_path()
-        );
-    }
-
-    public CreatedSeries toDomainModel() {
-        return new CreatedSeries(
-                name,
-                gender,
-                profilePath
-        );
-    }
-
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/LastEpisodeEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/LastEpisodeEntity.java
@@ -1,11 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.LastEpisode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class LastEpisodeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,37 +39,5 @@ public class LastEpisodeEntity {
         this.season_number = season_number;
         this.show_id = show_id;
         this.still_path = still_path;
-    }
-
-    public LastEpisode toDomainModel() {
-        return new LastEpisode(
-                id,
-                name,
-                overview,
-                vote_count,
-                air_date,
-                episode_number,
-                episode_type,
-                production_code,
-                runtime,
-                season_number,
-                show_id,
-                still_path
-        );
-    }
-    public static LastEpisodeEntity fromDomainModel(LastEpisode lastEpisode) {
-        return new LastEpisodeEntity(
-                lastEpisode.getName(),
-                lastEpisode.getOverview(),
-                lastEpisode.getVote_count(),
-                lastEpisode.getAir_date(),
-                lastEpisode.getEpisode_number(),
-                lastEpisode.getEpisode_type(),
-                lastEpisode.getProduction_code(),
-                lastEpisode.getRuntime(),
-                lastEpisode.getSeason_number(),
-                lastEpisode.getShow_id(),
-                lastEpisode.getStill_path()
-        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NetworksEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NetworksEntity.java
@@ -1,8 +1,11 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.Networks;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class NetworksEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,19 +22,4 @@ public class NetworksEntity {
 
     public NetworksEntity() {}
 
-    public Networks toDomainModel() {
-        return new Networks(
-                logo_path,
-                name,
-                origin_country
-        );
-    }
-
-    public static NetworksEntity fromDomainModel(Networks networks) {
-        return new NetworksEntity(
-                networks.getLogo_path(),
-                networks.getName(),
-                networks.getOrigin_country()
-        );
-    }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NextEpisodeEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NextEpisodeEntity.java
@@ -1,8 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +11,7 @@ public class NextEpisodeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     private String name;
+    @Column(length = 1000)
     private String overview;
     private float vote_average;
     private int vote_count;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NextEpisodeEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/NextEpisodeEntity.java
@@ -1,11 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.NextEpisode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class NextEpisodeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,40 +42,4 @@ public class NextEpisodeEntity {
         this.show_id = show_id;
         this.still_path = still_path;
     }
-
-    public NextEpisode toDomainModel() {
-        return new NextEpisode(
-                id,
-                name,
-                overview,
-                vote_average,
-                vote_count,
-                air_date,
-                episode_number,
-                episode_type,
-                production_code,
-                runtime,
-                season_number,
-                show_id,
-                still_path
-        );
-    }
-
-    public static NextEpisodeEntity fromDomainModel(NextEpisode nextEpisode) {
-        return new NextEpisodeEntity(
-                nextEpisode.getName(),
-                nextEpisode.getOverview(),
-                nextEpisode.getVote_average(),
-                nextEpisode.getVote_count(),
-                nextEpisode.getAir_date(),
-                nextEpisode.getEpisode_number(),
-                nextEpisode.getEpisode_type(),
-                nextEpisode.getProduction_code(),
-                nextEpisode.getRuntime(),
-                nextEpisode.getSeason_number(),
-                nextEpisode.getShow_id(),
-                nextEpisode.getStill_path()
-        );
-    }
-
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/OriginCountryEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/OriginCountryEntity.java
@@ -3,7 +3,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/OriginCountryEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/OriginCountryEntity.java
@@ -4,9 +4,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
 
 @Entity
+@Getter
+@Setter
 public class OriginCountryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,13 +21,5 @@ public class OriginCountryEntity {
 
     public OriginCountryEntity(String name) {
         this.name = name;
-    }
-
-    public String toDomainModel() {
-        return this.name;
-    }
-
-    public static OriginCountryEntity fromDomainModel(String country) {
-        return new OriginCountryEntity(country);
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SeasonsEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SeasonsEntity.java
@@ -1,8 +1,5 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,17 +11,12 @@ public class SeasonsEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
     private String airDate;
-
     private int episodeCount;
-
     private String name;
-
+    @Column(length = 1000)
     private String overview;
-
     private String posterPath;
-
     private int seasonNumber;
-
     private float voteAverage;
 
     public SeasonsEntity() {}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SeasonsEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SeasonsEntity.java
@@ -1,11 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.Seasons;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class SeasonsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,29 +37,5 @@ public class SeasonsEntity {
         this.posterPath = posterPath;
         this.seasonNumber = seasonNumber;
         this.voteAverage = voteAverage;
-    }
-
-    public Seasons toDomainModel() {
-        return new Seasons(
-                airDate,
-                episodeCount,
-                name,
-                overview,
-                posterPath,
-                seasonNumber,
-                voteAverage
-        );
-    }
-
-    public static SeasonsEntity fromDomainModel(Seasons seasons) {
-        return new SeasonsEntity(
-                seasons.getAir_date(),
-                seasons.getEpisode_count(),
-                seasons.getName(),
-                seasons.getOverview(),
-                seasons.getPoster_path(),
-                seasons.getSeason_number(),
-                seasons.getVote_average()
-        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SpokenLanguagesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/SpokenLanguagesEntity.java
@@ -1,11 +1,14 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.SpokenLanguages;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class SpokenLanguagesEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -14,28 +17,11 @@ public class SpokenLanguagesEntity {
     private String iso_639_1;
     private String name;
 
+    public SpokenLanguagesEntity() {}
+
     public SpokenLanguagesEntity(String english_name, String iso_639_1, String name) {
         this.english_name = english_name;
         this.iso_639_1 = iso_639_1;
         this.name = name;
-    }
-
-    public SpokenLanguages toDomainModel() {
-        return new SpokenLanguages(
-                english_name,
-                iso_639_1,
-                name
-        );
-    }
-
-    public SpokenLanguagesEntity() {}
-
-
-    public static SpokenLanguagesEntity fromDomainModel(SpokenLanguages spokenLanguages) {
-        return new SpokenLanguagesEntity(
-                spokenLanguages.getEnglish_name(),
-                spokenLanguages.getIso_639_1(),
-                spokenLanguages.getName()
-        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
@@ -45,6 +45,7 @@ public class TvSeriesEntity {
     private List<OriginCountryEntity> originCountry;
     private String originalLanguage;
     private String originalName;
+    @Column(length = 1000)
     private String overview;
     private float popularity;
     private String posterPath;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/entities/TvSeriesEntity.java
@@ -1,11 +1,12 @@
 package com.peliculas.peliculasapp.infrastructure.entities;
-import com.peliculas.peliculasapp.domain.models.*;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Entity
+@Getter
+@Setter
 public class TvSeriesEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,7 +16,6 @@ public class TvSeriesEntity {
     @JoinColumn(name = "tv_series_id")
     private List<CreatedSeriesEntity> createdBy;
     private String firstAirDate;
-
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "tv_series_id", referencedColumnName = "id")
     private List<GenreEntity> genres;
@@ -98,148 +98,5 @@ public class TvSeriesEntity {
         this.tagline = tagline;
         this.voteAverage = voteAverage;
         this.voteCount = voteCount;
-    }
-
-    public static TvSeriesEntity fromDomainModel(TvSeries tvSeries) {
-        List<CreatedSeriesEntity> createdSeriesEntityList = tvSeries.getCreated_by().stream()
-                .map(CreatedSeriesEntity::fromDomainModel)
-                .toList();
-
-        List<GenreEntity> genreEntityList = tvSeries.getGenres().stream()
-                .map(GenreEntity::fromDomainModel)
-                .toList();
-
-        LastEpisodeEntity lastEpisodeEntity = tvSeries.getLast_episode_to_air() != null ?
-                LastEpisodeEntity.fromDomainModel(tvSeries.getLast_episode_to_air()) :
-                null;
-
-        NextEpisodeEntity nextEpisodeEntity = tvSeries.getNext_episode_to_air() != null ?
-                NextEpisodeEntity.fromDomainModel(tvSeries.getNext_episode_to_air()) :
-                null;
-
-        List<NetworksEntity> networksEntity = tvSeries.getNetworks().stream()
-                .map(NetworksEntity::fromDomainModel)
-                .toList();
-
-        List<OriginCountryEntity> originCountryEntities = tvSeries.getOrigin_country().stream()
-                .map(OriginCountryEntity::fromDomainModel)
-                .toList();
-
-        List<ProductionCountriesEntity> productionCountriesEntities = tvSeries.getProduction_countries().stream()
-                .map(ProductionCountriesEntity::fromDomainModel)
-                .toList();
-
-        List<ProductionCompaniesEntity> productionCompanyEntities = tvSeries.getProduction_companies().stream()
-                .map(ProductionCompaniesEntity::fromDomainModel)
-                .toList();
-
-        List<SeasonsEntity> seasonsEntities = tvSeries.getSeasons().stream()
-                .map(SeasonsEntity::fromDomainModel)
-                .toList();
-
-        List<SpokenLanguagesEntity> spokenLanguagesEntities = tvSeries.getSpoken_languages().stream()
-                .map(SpokenLanguagesEntity::fromDomainModel)
-                .toList();
-
-        return new TvSeriesEntity(
-                tvSeries.getId(),
-                tvSeries.getBackdrop_path(),
-                createdSeriesEntityList,
-                tvSeries.getFirst_air_date(),
-                genreEntityList,
-                tvSeries.getHomepage(),
-                tvSeries.isIn_production(),
-                tvSeries.getLast_air_date(),
-                lastEpisodeEntity,
-                tvSeries.getName(),
-                nextEpisodeEntity,
-                networksEntity,
-                tvSeries.getNumber_of_episodes(),
-                tvSeries.getNumber_of_seasons(),
-                originCountryEntities,
-                tvSeries.getOriginal_language(),
-                tvSeries.getOriginal_name(),
-                tvSeries.getOverview(),
-                tvSeries.getPopularity(),
-                tvSeries.getPoster_path(),
-                productionCompanyEntities,
-                productionCountriesEntities,
-                seasonsEntities,
-                spokenLanguagesEntities,
-                tvSeries.getStatus(),
-                tvSeries.getTagline(),
-                tvSeries.getVote_average(),
-                tvSeries.getVote_count()
-
-        );
-    }
-
-    public Optional<TvSeries> toDomainModel() {
-        List<CreatedSeries> createdSeries = this.createdBy.stream()
-                .map(CreatedSeriesEntity::toDomainModel)
-                .toList();
-
-        List<Genre> genreList = this.genres.stream()
-                .map(GenreEntity::toDomainModel)
-                .toList();
-
-        LastEpisode lastEpisodeList = this.lastEpisodeToAir.toDomainModel();
-
-        NextEpisode nextEpisodeList = this.nextEpisodeToAir.toDomainModel();
-
-        List<Networks> networksList = this.networks.stream()
-                .map(NetworksEntity::toDomainModel)
-                .toList();
-
-        List<String> originCountryList = this.originCountry.stream()
-                .map(OriginCountryEntity::toDomainModel)
-                .toList();
-
-        List<ProductionCountries> productionCountries = this.productionCountries.stream()
-                .map(ProductionCountriesEntity::toDomainModel)
-                .collect(Collectors.toList());
-
-        List<ProductionCompany> productionCompanies = this.productionCompanies.stream()
-                .map(ProductionCompaniesEntity::toDomainModel)
-                .collect(Collectors.toList());
-
-        List<Seasons> seasonsList = this.seasons.stream()
-                .map(SeasonsEntity::toDomainModel)
-                .toList();
-
-        List<SpokenLanguages> spokenLanguagesList = this.spokenLanguages.stream()
-                .map(SpokenLanguagesEntity::toDomainModel)
-                .toList();
-
-        return Optional.of(new TvSeries(
-                id,
-                backdropPath,
-                createdSeries,
-                firstAirDate,
-                genreList,
-                homePage,
-                inProduction,
-                lastAirDate,
-                lastEpisodeList,
-                name,
-                nextEpisodeList,
-                networksList,
-                numberOfEpisodes,
-                numberOfSeasons,
-                originCountryList,
-                originalLanguage,
-                originalName,
-                overview,
-                popularity,
-                posterPath,
-                productionCompanies,
-                productionCountries,
-                seasonsList,
-                spokenLanguagesList,
-                status,
-                tagline,
-                voteAverage,
-                voteCount
-        ));
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/CreatedSeriesEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/CreatedSeriesEntityMapper.java
@@ -1,0 +1,23 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.CreatedSeries;
+import com.peliculas.peliculasapp.infrastructure.entities.CreatedSeriesEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class CreatedSeriesEntityMapper implements ListMapper<CreatedSeries, CreatedSeriesEntity> {
+    @Override
+    public List<CreatedSeriesEntity> fromDomainModel(List<CreatedSeries> createdSeries) {
+        return createdSeries.stream()
+                .map(createBySeries -> new CreatedSeriesEntity(createBySeries.getName(), createBySeries.getGender(), createBySeries.getProfile_path()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CreatedSeries> toDomainModel(List<CreatedSeriesEntity> createdSeriesEntities) {
+        return createdSeriesEntities.stream()
+                .map(createBySeries -> new CreatedSeries(createBySeries.getName(), createBySeries.getGender(), createBySeries.getProfilePath()))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/DomainEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/DomainEntityMapper.java
@@ -1,0 +1,6 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+
+public interface DomainEntityMapper<S, T> {
+    T fromDomainModel(S source);
+    S toDomainModel(T target);
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/GenreEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/GenreEntityMapper.java
@@ -6,13 +6,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-public class GenreEntityMapper {
+public class GenreEntityMapper implements ListMapper<Genre, GenreEntity> {
+    @Override
     public List<GenreEntity> fromDomainModel(List<Genre> genres) {
         return genres.stream()
                 .map(genre -> new GenreEntity(genre.getName()))
                 .collect(Collectors.toList());
     }
 
+    @Override
     public List<Genre> toDomainModel(List<GenreEntity> genres) {
         return genres.stream()
                 .map(genre -> new Genre(genre.getName()))

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/LastEpisodeEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/LastEpisodeEntityMapper.java
@@ -1,0 +1,49 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.LastEpisode;
+import com.peliculas.peliculasapp.infrastructure.entities.LastEpisodeEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class LastEpisodeEntityMapper implements ListMapper<LastEpisode, LastEpisodeEntity>{
+
+    @Override
+    public List<LastEpisodeEntity> fromDomainModel(List<LastEpisode> lastEpisodeList) {
+        return lastEpisodeList.stream()
+                .map(lastEpisode -> new LastEpisodeEntity(
+                        lastEpisode.getName(),
+                        lastEpisode.getOverview(),
+                        lastEpisode.getVote_count(),
+                        lastEpisode.getAir_date(),
+                        lastEpisode.getEpisode_number(),
+                        lastEpisode.getEpisode_type(),
+                        lastEpisode.getProduction_code(),
+                        lastEpisode.getRuntime(),
+                        lastEpisode.getSeason_number(),
+                        lastEpisode.getShow_id(),
+                        lastEpisode.getStill_path()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<LastEpisode> toDomainModel(List<LastEpisodeEntity> lastEpisodeEntityList) {
+        return lastEpisodeEntityList.stream()
+                .map(lastEpisodeEntity -> new LastEpisode(
+                        lastEpisodeEntity.getId(),
+                        lastEpisodeEntity.getName(),
+                        lastEpisodeEntity.getOverview(),
+                        lastEpisodeEntity.getVote_count(),
+                        lastEpisodeEntity.getAir_date(),
+                        lastEpisodeEntity.getEpisode_number(),
+                        lastEpisodeEntity.getEpisode_type(),
+                        lastEpisodeEntity.getProduction_code(),
+                        lastEpisodeEntity.getRuntime(),
+                        lastEpisodeEntity.getSeason_number(),
+                        lastEpisodeEntity.getShow_id(),
+                        lastEpisodeEntity.getStill_path()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/LastEpisodeEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/LastEpisodeEntityMapper.java
@@ -2,48 +2,41 @@ package com.peliculas.peliculasapp.infrastructure.mapper;
 import com.peliculas.peliculasapp.domain.models.LastEpisode;
 import com.peliculas.peliculasapp.infrastructure.entities.LastEpisodeEntity;
 import org.springframework.stereotype.Component;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
-public class LastEpisodeEntityMapper implements ListMapper<LastEpisode, LastEpisodeEntity>{
-
+public class LastEpisodeEntityMapper implements DomainEntityMapper<LastEpisode, LastEpisodeEntity>{
     @Override
-    public List<LastEpisodeEntity> fromDomainModel(List<LastEpisode> lastEpisodeList) {
-        return lastEpisodeList.stream()
-                .map(lastEpisode -> new LastEpisodeEntity(
-                        lastEpisode.getName(),
-                        lastEpisode.getOverview(),
-                        lastEpisode.getVote_count(),
-                        lastEpisode.getAir_date(),
-                        lastEpisode.getEpisode_number(),
-                        lastEpisode.getEpisode_type(),
-                        lastEpisode.getProduction_code(),
-                        lastEpisode.getRuntime(),
-                        lastEpisode.getSeason_number(),
-                        lastEpisode.getShow_id(),
-                        lastEpisode.getStill_path()
-                ))
-                .collect(Collectors.toList());
+    public LastEpisodeEntity fromDomainModel(LastEpisode lastEpisodeList) {
+        return new LastEpisodeEntity(
+                lastEpisodeList.getName(),
+                lastEpisodeList.getOverview(),
+                lastEpisodeList.getVote_count(),
+                lastEpisodeList.getAir_date(),
+                lastEpisodeList.getEpisode_number(),
+                lastEpisodeList.getEpisode_type(),
+                lastEpisodeList.getProduction_code(),
+                lastEpisodeList.getRuntime(),
+                lastEpisodeList.getSeason_number(),
+                lastEpisodeList.getShow_id(),
+                lastEpisodeList.getStill_path()
+        );
     }
 
     @Override
-    public List<LastEpisode> toDomainModel(List<LastEpisodeEntity> lastEpisodeEntityList) {
-        return lastEpisodeEntityList.stream()
-                .map(lastEpisodeEntity -> new LastEpisode(
-                        lastEpisodeEntity.getId(),
-                        lastEpisodeEntity.getName(),
-                        lastEpisodeEntity.getOverview(),
-                        lastEpisodeEntity.getVote_count(),
-                        lastEpisodeEntity.getAir_date(),
-                        lastEpisodeEntity.getEpisode_number(),
-                        lastEpisodeEntity.getEpisode_type(),
-                        lastEpisodeEntity.getProduction_code(),
-                        lastEpisodeEntity.getRuntime(),
-                        lastEpisodeEntity.getSeason_number(),
-                        lastEpisodeEntity.getShow_id(),
-                        lastEpisodeEntity.getStill_path()
-                ))
-                .collect(Collectors.toList());
+    public LastEpisode toDomainModel(LastEpisodeEntity lastEpisodeEntity) {
+       return new LastEpisode(
+               lastEpisodeEntity.getId(),
+               lastEpisodeEntity.getName(),
+               lastEpisodeEntity.getOverview(),
+               lastEpisodeEntity.getVote_count(),
+               lastEpisodeEntity.getAir_date(),
+               lastEpisodeEntity.getEpisode_number(),
+               lastEpisodeEntity.getEpisode_type(),
+               lastEpisodeEntity.getProduction_code(),
+               lastEpisodeEntity.getRuntime(),
+               lastEpisodeEntity.getSeason_number(),
+               lastEpisodeEntity.getShow_id(),
+               lastEpisodeEntity.getStill_path()
+       );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ListMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ListMapper.java
@@ -1,0 +1,8 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import java.util.List;
+
+public interface ListMapper<S, T>{
+    List<T> fromDomainModel(List<S> sourceList);
+    List<S> toDomainModel(List<T> sourceList);
+}
+

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ListMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/ListMapper.java
@@ -5,4 +5,3 @@ public interface ListMapper<S, T>{
     List<T> fromDomainModel(List<S> sourceList);
     List<S> toDomainModel(List<T> sourceList);
 }
-

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NetworksEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NetworksEntityMapper.java
@@ -1,0 +1,31 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.Networks;
+import com.peliculas.peliculasapp.infrastructure.entities.NetworksEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class NetworksEntityMapper implements ListMapper<Networks, NetworksEntity>{
+    @Override
+    public List<NetworksEntity> fromDomainModel(List<Networks> networksList) {
+        return networksList.stream()
+                .map(networks -> new NetworksEntity(
+                        networks.getLogo_path(),
+                        networks.getName(),
+                        networks.getOrigin_country()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Networks> toDomainModel(List<NetworksEntity> networksEntityList) {
+        return networksEntityList.stream()
+                .map(networksEntity -> new Networks(
+                        networksEntity.getLogo_path(),
+                        networksEntity.getName(),
+                        networksEntity.getOrigin_country()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NextEpisodeEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NextEpisodeEntityMapper.java
@@ -1,0 +1,50 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.NextEpisode;
+import com.peliculas.peliculasapp.infrastructure.entities.NextEpisodeEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class NextEpisodeEntityMapper implements ListMapper<NextEpisode, NextEpisodeEntity>{
+    @Override
+    public List<NextEpisodeEntity> fromDomainModel(List<NextEpisode> nextEpisodesList) {
+        return nextEpisodesList.stream()
+                .map(nextEpisode -> new NextEpisodeEntity(
+                        nextEpisode.getName(),
+                        nextEpisode.getOverview(),
+                        nextEpisode.getVote_average(),
+                        nextEpisode.getVote_count(),
+                        nextEpisode.getAir_date(),
+                        nextEpisode.getEpisode_number(),
+                        nextEpisode.getEpisode_type(),
+                        nextEpisode.getProduction_code(),
+                        nextEpisode.getRuntime(),
+                        nextEpisode.getSeason_number(),
+                        nextEpisode.getShow_id(),
+                        nextEpisode.getStill_path()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<NextEpisode> toDomainModel(List<NextEpisodeEntity> nextEpisodeEntityList) {
+        return nextEpisodeEntityList.stream()
+                .map(nextEpisodeEntity -> new NextEpisode(
+                        nextEpisodeEntity.getId(),
+                        nextEpisodeEntity.getName(),
+                        nextEpisodeEntity.getOverview(),
+                        nextEpisodeEntity.getVote_average(),
+                        nextEpisodeEntity.getVote_count(),
+                        nextEpisodeEntity.getAir_date(),
+                        nextEpisodeEntity.getEpisode_number(),
+                        nextEpisodeEntity.getEpisode_type(),
+                        nextEpisodeEntity.getProduction_code(),
+                        nextEpisodeEntity.getRuntime(),
+                        nextEpisodeEntity.getSeason_number(),
+                        nextEpisodeEntity.getShow_id(),
+                        nextEpisodeEntity.getStill_path()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NextEpisodeEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NextEpisodeEntityMapper.java
@@ -2,49 +2,43 @@ package com.peliculas.peliculasapp.infrastructure.mapper;
 import com.peliculas.peliculasapp.domain.models.NextEpisode;
 import com.peliculas.peliculasapp.infrastructure.entities.NextEpisodeEntity;
 import org.springframework.stereotype.Component;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
-public class NextEpisodeEntityMapper implements ListMapper<NextEpisode, NextEpisodeEntity>{
+public class NextEpisodeEntityMapper implements DomainEntityMapper<NextEpisode, NextEpisodeEntity>{
     @Override
-    public List<NextEpisodeEntity> fromDomainModel(List<NextEpisode> nextEpisodesList) {
-        return nextEpisodesList.stream()
-                .map(nextEpisode -> new NextEpisodeEntity(
-                        nextEpisode.getName(),
-                        nextEpisode.getOverview(),
-                        nextEpisode.getVote_average(),
-                        nextEpisode.getVote_count(),
-                        nextEpisode.getAir_date(),
-                        nextEpisode.getEpisode_number(),
-                        nextEpisode.getEpisode_type(),
-                        nextEpisode.getProduction_code(),
-                        nextEpisode.getRuntime(),
-                        nextEpisode.getSeason_number(),
-                        nextEpisode.getShow_id(),
-                        nextEpisode.getStill_path()
-                ))
-                .collect(Collectors.toList());
+    public NextEpisodeEntity fromDomainModel(NextEpisode nextEpisode) {
+        return new NextEpisodeEntity(
+                nextEpisode.getName(),
+                nextEpisode.getOverview(),
+                nextEpisode.getVote_average(),
+                nextEpisode.getVote_count(),
+                nextEpisode.getAir_date(),
+                nextEpisode.getEpisode_number(),
+                nextEpisode.getEpisode_type(),
+                nextEpisode.getProduction_code(),
+                nextEpisode.getRuntime(),
+                nextEpisode.getSeason_number(),
+                nextEpisode.getShow_id(),
+                nextEpisode.getStill_path()
+        );
     }
 
     @Override
-    public List<NextEpisode> toDomainModel(List<NextEpisodeEntity> nextEpisodeEntityList) {
-        return nextEpisodeEntityList.stream()
-                .map(nextEpisodeEntity -> new NextEpisode(
-                        nextEpisodeEntity.getId(),
-                        nextEpisodeEntity.getName(),
-                        nextEpisodeEntity.getOverview(),
-                        nextEpisodeEntity.getVote_average(),
-                        nextEpisodeEntity.getVote_count(),
-                        nextEpisodeEntity.getAir_date(),
-                        nextEpisodeEntity.getEpisode_number(),
-                        nextEpisodeEntity.getEpisode_type(),
-                        nextEpisodeEntity.getProduction_code(),
-                        nextEpisodeEntity.getRuntime(),
-                        nextEpisodeEntity.getSeason_number(),
-                        nextEpisodeEntity.getShow_id(),
-                        nextEpisodeEntity.getStill_path()
-                ))
-                .collect(Collectors.toList());
+    public NextEpisode toDomainModel(NextEpisodeEntity nextEpisodeEntity) {
+        return new NextEpisode(
+                nextEpisodeEntity.getId(),
+                nextEpisodeEntity.getName(),
+                nextEpisodeEntity.getOverview(),
+                nextEpisodeEntity.getVote_average(),
+                nextEpisodeEntity.getVote_count(),
+                nextEpisodeEntity.getAir_date(),
+                nextEpisodeEntity.getEpisode_number(),
+                nextEpisodeEntity.getEpisode_type(),
+                nextEpisodeEntity.getProduction_code(),
+                nextEpisodeEntity.getRuntime(),
+                nextEpisodeEntity.getSeason_number(),
+                nextEpisodeEntity.getShow_id(),
+                nextEpisodeEntity.getStill_path()
+        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NextEpisodeEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/NextEpisodeEntityMapper.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Component;
 public class NextEpisodeEntityMapper implements DomainEntityMapper<NextEpisode, NextEpisodeEntity>{
     @Override
     public NextEpisodeEntity fromDomainModel(NextEpisode nextEpisode) {
+        if (nextEpisode == null) {
+            return null;
+        }
         return new NextEpisodeEntity(
                 nextEpisode.getName(),
                 nextEpisode.getOverview(),

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/OriginCountryMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/OriginCountryMapper.java
@@ -1,0 +1,17 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.infrastructure.entities.OriginCountryEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OriginCountryMapper implements DomainEntityMapper<String, OriginCountryEntity> {
+
+    @Override
+    public OriginCountryEntity fromDomainModel(String country) {
+        return new OriginCountryEntity(country);
+    }
+
+    @Override
+    public String toDomainModel(OriginCountryEntity originCountryEntity) {
+        return originCountryEntity.getName();
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/SeasonsEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/SeasonsEntityMapper.java
@@ -1,0 +1,39 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.Seasons;
+import com.peliculas.peliculasapp.infrastructure.entities.SeasonsEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class SeasonsEntityMapper implements ListMapper<Seasons, SeasonsEntity>{
+    @Override
+    public List<SeasonsEntity> fromDomainModel(List<Seasons> seasonsList) {
+        return seasonsList.stream()
+                .map(seasons -> new SeasonsEntity(
+                        seasons.getAir_date(),
+                        seasons.getEpisode_count(),
+                        seasons.getName(),
+                        seasons.getOverview(),
+                        seasons.getPoster_path(),
+                        seasons.getSeason_number(),
+                        seasons.getVote_average()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Seasons> toDomainModel(List<SeasonsEntity> seasonsEntityList) {
+        return seasonsEntityList.stream()
+                .map(seasonsEntity -> new Seasons(
+                        seasonsEntity.getAirDate(),
+                        seasonsEntity.getEpisodeCount(),
+                        seasonsEntity.getName(),
+                        seasonsEntity.getOverview(),
+                        seasonsEntity.getPosterPath(),
+                        seasonsEntity.getSeasonNumber(),
+                        seasonsEntity.getVoteAverage()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/SpokenLanguagesEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/SpokenLanguagesEntityMapper.java
@@ -1,0 +1,31 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+import com.peliculas.peliculasapp.domain.models.SpokenLanguages;
+import com.peliculas.peliculasapp.infrastructure.entities.SpokenLanguagesEntity;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class SpokenLanguagesEntityMapper implements ListMapper<SpokenLanguages, SpokenLanguagesEntity>{
+    @Override
+    public List<SpokenLanguagesEntity> fromDomainModel(List<SpokenLanguages> spokenLanguagesList) {
+        return spokenLanguagesList.stream()
+                .map(spokenLanguages -> new SpokenLanguagesEntity(
+                        spokenLanguages.getEnglish_name(),
+                        spokenLanguages.getIso_639_1(),
+                        spokenLanguages.getName()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<SpokenLanguages> toDomainModel(List<SpokenLanguagesEntity> spokenLanguagesEntityList) {
+        return spokenLanguagesEntityList.stream()
+                .map(spokenLanguagesEntity -> new SpokenLanguages(
+                        spokenLanguagesEntity.getEnglish_name(),
+                        spokenLanguagesEntity.getIso_639_1(),
+                        spokenLanguagesEntity.getName()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/TvSeriesEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/TvSeriesEntityMapper.java
@@ -1,12 +1,138 @@
 package com.peliculas.peliculasapp.infrastructure.mapper;
-
-import com.peliculas.peliculasapp.domain.models.TvSeries;
-import com.peliculas.peliculasapp.infrastructure.entities.TvSeriesEntity;
+import com.peliculas.peliculasapp.domain.models.*;
+import com.peliculas.peliculasapp.infrastructure.entities.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class TvSeriesEntityMapper {
+    private final CreatedSeriesEntityMapper createdSeriesEntityMapper;
+    private final GenreEntityMapper genreEntityMapper;
+    private final LastEpisodeEntityMapper lastEpisodeEntityMapper;
+    private final NextEpisodeEntityMapper nextEpisodeEntityMapper;
+    private final NetworksEntityMapper networksEntityMapper;
+    private final OriginCountryMapper originCountryMapper;
+    private final ProductionCountriesEntityMapper productionCountriesEntityMapper;
+    private final ProductionCompaniesEntityMapper productionCompaniesEntityMapper;
+    private final SeasonsEntityMapper seasonsEntityMapper;
+    private final SpokenLanguagesEntityMapper spokenLanguagesEntityMapper;
+
+    @Autowired
+    public TvSeriesEntityMapper(CreatedSeriesEntityMapper createdSeriesEntityMapper,
+                                GenreEntityMapper genreEntityMapper,
+                                LastEpisodeEntityMapper lastEpisodeEntityMapper,
+                                NextEpisodeEntityMapper nextEpisodeEntityMapper,
+                                NetworksEntityMapper networksEntityMapper,
+                                OriginCountryMapper originCountryMapper,
+                                ProductionCountriesEntityMapper productionCountriesEntityMapper,
+                                ProductionCompaniesEntityMapper productionCompaniesEntityMapper,
+                                SeasonsEntityMapper seasonsEntityMapper,
+                                SpokenLanguagesEntityMapper spokenLanguagesEntityMapper)
+    {
+        this.createdSeriesEntityMapper = createdSeriesEntityMapper;
+        this.genreEntityMapper = genreEntityMapper;
+        this.lastEpisodeEntityMapper = lastEpisodeEntityMapper;
+        this.nextEpisodeEntityMapper = nextEpisodeEntityMapper;
+        this.networksEntityMapper = networksEntityMapper;
+        this.originCountryMapper = originCountryMapper;
+        this.productionCountriesEntityMapper = productionCountriesEntityMapper;
+        this.productionCompaniesEntityMapper = productionCompaniesEntityMapper;
+        this.seasonsEntityMapper = seasonsEntityMapper;
+        this.spokenLanguagesEntityMapper = spokenLanguagesEntityMapper;
+    }
+
     public TvSeriesEntity fromDomainModel(TvSeries tvSeries) {
-        return
+        List<CreatedSeriesEntity> createdSeriesEntityList = createdSeriesEntityMapper.fromDomainModel(tvSeries.getCreated_by());
+        List<GenreEntity>  genreEntityList = genreEntityMapper.fromDomainModel(tvSeries.getGenres());
+        LastEpisodeEntity lastEpisodeEntity = lastEpisodeEntityMapper.fromDomainModel(tvSeries.getLast_episode_to_air());
+        NextEpisodeEntity nextEpisodeEntity = nextEpisodeEntityMapper.fromDomainModel(tvSeries.getNext_episode_to_air());
+        List<NetworksEntity> networksEntity = networksEntityMapper.fromDomainModel(tvSeries.getNetworks());
+        List<OriginCountryEntity> originCountryEntities = tvSeries.getOrigin_country().stream()
+                .map(originCountryMapper::fromDomainModel)
+                .collect(Collectors.toList());
+        List<ProductionCountriesEntity> productionCountriesEntities = productionCountriesEntityMapper.fromDomainModel(tvSeries.getProduction_countries());
+        List<ProductionCompaniesEntity> productionCompaniesEntities = productionCompaniesEntityMapper.fromDomainModel(tvSeries.getProduction_companies());
+        List<SeasonsEntity> seasonsEntities = seasonsEntityMapper.fromDomainModel(tvSeries.getSeasons());
+        List<SpokenLanguagesEntity> spokenLanguagesEntities = spokenLanguagesEntityMapper.fromDomainModel(tvSeries.getSpoken_languages());
+
+
+        return new TvSeriesEntity(
+                tvSeries.getId(),
+                tvSeries.getBackdrop_path(),
+                createdSeriesEntityList,
+                tvSeries.getFirst_air_date(),
+                genreEntityList,
+                tvSeries.getHomepage(),
+                tvSeries.isIn_production(),
+                tvSeries.getLast_air_date(),
+                lastEpisodeEntity,
+                tvSeries.getName(),
+                nextEpisodeEntity,
+                networksEntity,
+                tvSeries.getNumber_of_episodes(),
+                tvSeries.getNumber_of_seasons(),
+                originCountryEntities,
+                tvSeries.getOriginal_language(),
+                tvSeries.getOriginal_name(),
+                tvSeries.getOverview(),
+                tvSeries.getPopularity(),
+                tvSeries.getPoster_path(),
+                productionCompaniesEntities,
+                productionCountriesEntities,
+                seasonsEntities,
+                spokenLanguagesEntities,
+                tvSeries.getStatus(),
+                tvSeries.getTagline(),
+                tvSeries.getVote_average(),
+                tvSeries.getVote_count()
+        );
+    }
+
+    public TvSeries toDomainModel(TvSeriesEntity tvSeriesEntity) {
+        List<CreatedSeries> createdSeriesList = createdSeriesEntityMapper.toDomainModel(tvSeriesEntity.getCreatedBy());
+        List<Genre> genreList = genreEntityMapper.toDomainModel(tvSeriesEntity.getGenres());
+        LastEpisode lastEpisode = lastEpisodeEntityMapper.toDomainModel(tvSeriesEntity.getLastEpisodeToAir());
+        NextEpisode nextEpisode = nextEpisodeEntityMapper.toDomainModel(tvSeriesEntity.getNextEpisodeToAir());
+        List<Networks> networksList = networksEntityMapper.toDomainModel(tvSeriesEntity.getNetworks());
+        List<String> originCountryList = tvSeriesEntity.getOriginCountry().stream()
+                .map(originCountryMapper::toDomainModel)
+                .collect(Collectors.toList());
+        List<ProductionCountries> productionCountriesList = productionCountriesEntityMapper.toDomainModel(tvSeriesEntity.getProductionCountries());
+        List<ProductionCompany> productionCompaniesList = productionCompaniesEntityMapper.toDomainModel(tvSeriesEntity.getProductionCompanies());
+        List<Seasons> seasonsList = seasonsEntityMapper.toDomainModel(tvSeriesEntity.getSeasons());
+        List<SpokenLanguages> spokenLanguagesList = spokenLanguagesEntityMapper.toDomainModel(tvSeriesEntity.getSpokenLanguages());
+
+        return new TvSeries(
+                tvSeriesEntity.getId(),
+                tvSeriesEntity.getBackdropPath(),
+                createdSeriesList,
+                tvSeriesEntity.getFirstAirDate(),
+                genreList,
+                tvSeriesEntity.getHomePage(),
+                tvSeriesEntity.isInProduction(),
+                tvSeriesEntity.getLastAirDate(),
+                lastEpisode,
+                tvSeriesEntity.getName(),
+                nextEpisode,
+                networksList,
+                tvSeriesEntity.getNumberOfEpisodes(),
+                tvSeriesEntity.getNumberOfSeasons(),
+                originCountryList,
+                tvSeriesEntity.getOriginalLanguage(),
+                tvSeriesEntity.getOriginalName(),
+                tvSeriesEntity.getOverview(),
+                tvSeriesEntity.getPopularity(),
+                tvSeriesEntity.getPosterPath(),
+                productionCompaniesList,
+                productionCountriesList,
+                seasonsList,
+                spokenLanguagesList,
+                tvSeriesEntity.getStatus(),
+                tvSeriesEntity.getTagline(),
+                tvSeriesEntity.getVoteAverage(),
+                tvSeriesEntity.getVoteCount()
+        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/TvSeriesEntityMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/mapper/TvSeriesEntityMapper.java
@@ -1,0 +1,12 @@
+package com.peliculas.peliculasapp.infrastructure.mapper;
+
+import com.peliculas.peliculasapp.domain.models.TvSeries;
+import com.peliculas.peliculasapp.infrastructure.entities.TvSeriesEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TvSeriesEntityMapper {
+    public TvSeriesEntity fromDomainModel(TvSeries tvSeries) {
+        return
+    }
+}


### PR DESCRIPTION
Descripción:
Este conjunto de cambios refactoriza la implementación de `TvSeriesRepositoryJpaImpl` para mejorar la coherencia y claridad del código, además de corregir un error que impedía guardar series debido a la longitud de la columna.

Cambios realizados:
- Se aplicó el patrón de diseño Mapper para separar la lógica de mapeo de objetos de dominio y entidades JPA.
- Se reemplazaron las conversiones directas entre objetos de dominio y entidades por el uso de mappers en los métodos `saveTvSeries`(), `getTvSeriesInfo`() y getTvSeriesById() para garantizar una gestión adecuada de la persistencia y la recuperación de datos.
- Se implementaron métodos específicos en el mapper `TvSeriesMapper` para manejar las conversiones entre `TvSeries` y `TvSeriesEntity` de manera consistente.
- Se corrigió un error que causaba que no se pudieran guardar series debido a la longitud de la columna, realizando los ajustes necesarios en la configuración de la base de datos y en las entidades correspondientes.

Impacto:
Estos cambios mejoran la legibilidad, mantenibilidad y robustez del código en `TvSeriesRepositoryJpaImpl`. Además, garantizan un comportamiento correcto al guardar series, asegurando que la longitud de la columna no sea un obstáculo para la persistencia de datos.
