### PR TITLE
feat: implement method findReviewsByMovieId

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/mapper/MovieReviewDtoMapper.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/mapper/MovieReviewDtoMapper.java
@@ -1,0 +1,21 @@
+package com.peliculas.peliculasapp.application.mapper;
+import com.peliculas.peliculasapp.domain.dto.MovieReviewDTO;
+import com.peliculas.peliculasapp.domain.models.MovieReview;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MovieReviewDtoMapper {
+    public MovieReviewDTO toDto(MovieReview movieReview) {
+        MovieReviewDTO dto = new MovieReviewDTO();
+        dto.setId(movieReview.getId());
+        dto.setReviewText(movieReview.getReviewText());
+        dto.setRating(movieReview.getRating());
+        dto.setCreatedAt(movieReview.getCreatedAt());
+        dto.setUpdatedAt(movieReview.getUpdatedAt());
+        dto.setMovieId(movieReview.getMovieId());
+        dto.setTitle(movieReview.getMovie().getTitle());
+        dto.setUserId(movieReview.getUser().getId());
+        dto.setUsername(movieReview.getUser().getUsername());
+        return dto;
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/in/MovieReviewUseCase.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/in/MovieReviewUseCase.java
@@ -2,11 +2,12 @@ package com.peliculas.peliculasapp.application.ports.in;
 import com.peliculas.peliculasapp.domain.models.MovieReview;
 import com.peliculas.peliculasapp.domain.dto.MovieReviewDTO;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MovieReviewUseCase {
     Optional<MovieReviewDTO> createMovieReview(MovieReview movieReview);
     Optional<MovieReview> updateMovieReview(MovieReview review);
-    Optional<MovieReview> findReviewsByMovieId(long reviewId);
+    List<MovieReviewDTO> findReviewsByMovieId(long reviewId);
     Optional<MovieReview> deleteReviewById(long reviewId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieReviewRepositoryPort.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieReviewRepositoryPort.java
@@ -1,10 +1,12 @@
 package com.peliculas.peliculasapp.application.ports.out;
 import com.peliculas.peliculasapp.domain.models.MovieReview;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface MovieReviewRepositoryPort {
     Optional<MovieReview> createMovieReview(MovieReview review);
     Optional<MovieReview> updateMovieReview(MovieReview review);
-    Optional<MovieReview> findReviewsByMovieId(long reviewId);
+    List<MovieReview> findReviewsByMovieId(long reviewId);
     Optional<MovieReview> deleteReviewById(long reviewId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/services/MovieReviewService.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/services/MovieReviewService.java
@@ -2,18 +2,26 @@ package com.peliculas.peliculasapp.application.services;
 import com.peliculas.peliculasapp.application.ports.in.MovieReviewUseCase;
 import com.peliculas.peliculasapp.domain.models.MovieReview;
 import com.peliculas.peliculasapp.domain.dto.MovieReviewDTO;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 import java.util.Optional;
 
 @Service
 public class MovieReviewService {
     private final MovieReviewUseCase movieReviewUseCase;
 
+    @Autowired
     public MovieReviewService(MovieReviewUseCase movieReviewUseCase) {
         this.movieReviewUseCase = movieReviewUseCase;
     }
 
     public Optional<MovieReviewDTO> createMovieReview(MovieReview movieReview) {
         return movieReviewUseCase.createMovieReview(movieReview);
+    }
+
+    public List<MovieReviewDTO> findReviewsByMovieId(long reviewId) {
+        return movieReviewUseCase.findReviewsByMovieId(reviewId);
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/MovieReviewUseCaseImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/MovieReviewUseCaseImpl.java
@@ -1,17 +1,24 @@
 package com.peliculas.peliculasapp.application.usecases;
+import com.peliculas.peliculasapp.application.mapper.MovieReviewDtoMapper;
 import com.peliculas.peliculasapp.application.ports.in.MovieReviewUseCase;
 import com.peliculas.peliculasapp.application.ports.out.MovieReviewRepositoryPort;
 import com.peliculas.peliculasapp.domain.models.MovieReview;
 import com.peliculas.peliculasapp.domain.dto.MovieReviewDTO;
 import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class MovieReviewUseCaseImpl implements MovieReviewUseCase {
+    private final MovieReviewDtoMapper movieReviewMapper;
     private final MovieReviewRepositoryPort movieReviewRepositoryPort;
     private final ModelMapper modelMapper;
-    public MovieReviewUseCaseImpl(MovieReviewRepositoryPort movieReviewRepositoryPort, ModelMapper modelMapper) {
+    @Autowired
+    public MovieReviewUseCaseImpl(MovieReviewDtoMapper movieReviewMapper, MovieReviewRepositoryPort movieReviewRepositoryPort, ModelMapper modelMapper) {
+        this.movieReviewMapper = movieReviewMapper;
         this.movieReviewRepositoryPort = movieReviewRepositoryPort;
         this.modelMapper = modelMapper;
     }
@@ -27,8 +34,11 @@ public class MovieReviewUseCaseImpl implements MovieReviewUseCase {
     }
 
     @Override
-    public Optional<MovieReview> findReviewsByMovieId(long reviewId) {
-        return Optional.empty();
+    public List<MovieReviewDTO> findReviewsByMovieId(long reviewId) {
+        List<MovieReview> movieReview = movieReviewRepositoryPort.findReviewsByMovieId(reviewId);
+        return movieReview.stream()
+                .map(movieReviewMapper::toDto)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/dto/MovieReviewDTO.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/dto/MovieReviewDTO.java
@@ -1,17 +1,18 @@
 package com.peliculas.peliculasapp.domain.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.peliculas.peliculasapp.domain.models.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class MovieReviewDTO {
-    private Long id;
+    private long id;
     @JsonProperty("movie_id")
+    private String title;
     private Long movieId;
     @JsonProperty("user_id")
     private Long userId;
@@ -20,5 +21,8 @@ public class MovieReviewDTO {
     private String reviewText;
     @JsonProperty("created_at")
     private LocalDateTime createdAt;
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+    private String username;
 }
 

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/Movie.java
@@ -32,6 +32,8 @@ public class Movie {
 
     private String release_date;
 
+    private Movie() {}
+
     public Movie(long id, String overview, String status, List<ProductionCompany> productionCompanies, List<Genre> genres, List<ProductionCountries> productionCountries, String title, float voteAverage, float voteCount, long revenue, int budget, float popularity, String posterPath, String releaseDate) {
         this.id = id;
         this.overview = overview;

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/MovieReview.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/domain/models/MovieReview.java
@@ -15,8 +15,11 @@ public class MovieReview {
     private long movieId;
     @JsonProperty("user_id")
     private long userId;
+    private User user;
     private int rating;
     @JsonProperty("review_text")
     private String reviewText;
+    private Movie movie;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/exceptions/MovieReviewNotFoundException.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/exceptions/MovieReviewNotFoundException.java
@@ -1,0 +1,7 @@
+package com.peliculas.peliculasapp.infrastructure.adapter.exceptions;
+
+public class MovieReviewNotFoundException extends RuntimeException {
+    public MovieReviewNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepository.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepository.java
@@ -1,10 +1,18 @@
 package com.peliculas.peliculasapp.infrastructure.adapter.repositories;
 import com.peliculas.peliculasapp.infrastructure.adapter.entities.MovieReviewEntity;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 @Repository
 @Transactional
 public interface MovieReviewRepository extends JpaRepository<MovieReviewEntity, Long> {
+    @Query(value = "SELECT r FROM MovieReviewEntity r " +
+            "JOIN FETCH r.user u " +
+            "JOIN FETCH r.movie m " +
+            "WHERE r.movie.id = :movieId")
+    List<MovieReviewEntity> findReviewsByMovieId(@Param("movieId") long movieId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepositoryJpaImpl.java
@@ -10,6 +10,7 @@ import com.peliculas.peliculasapp.infrastructure.adapter.mapper.MovieReviewMappe
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -58,9 +59,11 @@ public class MovieReviewRepositoryJpaImpl implements MovieReviewRepositoryPort {
     }
 
     @Override
-    public Optional<MovieReview> findReviewsByMovieId(long reviewId) {
-        // TODO: Implement
-        return Optional.empty();
+    public List<MovieReview> findReviewsByMovieId(long reviewId) {
+        List<MovieReviewEntity> movieReviewEntities = movieReviewRepository.findReviewsByMovieId(reviewId);
+        return movieReviewEntities.stream()
+                .map(movieReviewMapper::toDomainModel)
+                .toList();
     }
 
     @Override

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/rest/controllers/MovieReviewController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/rest/controllers/MovieReviewController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -23,6 +24,13 @@ public class MovieReviewController {
     public ResponseEntity<?> createMovieReview(@RequestBody MovieReview movieReview) {
         Optional<MovieReviewDTO> createdReview = movieReviewService.createMovieReview(movieReview);
         SuccessResponse successResponse = new SuccessResponse(HttpStatus.OK.value(), "Review de pelicula creada con exito", createdReview);
+        return ResponseEntity.ok(successResponse);
+    }
+
+    @GetMapping("/movies/review/{reviewId}")
+    public ResponseEntity<?> getMovieReviewById(@PathVariable long reviewId) {
+        List<MovieReviewDTO> movieReviewDTO = movieReviewService.findReviewsByMovieId(reviewId);
+        SuccessResponse successResponse = new SuccessResponse(HttpStatus.OK.value(), "Review obtenida con exito", movieReviewDTO);
         return ResponseEntity.ok(successResponse);
     }
 }


### PR DESCRIPTION
### Descripción del PR:

* Se agregó el método `findReviewsByMovieId` a `MovieReviewRepository`, permitiendo consultas personalizadas para recuperar reseñas de películas por su ID.
* La consulta personalizada selecciona campos específicos de las entidades `MovieReviewEntity`, `UserEntity` y `MovieEntity`, enriqueciendo la información sobre las reseñas con detalles como el título de la película y el nombre del usuario.
* Se corrigió un problema de mapeo que causaba resultados nulos al cambiar el tipo de retorno de `Optional` a `List`, asegurando una recuperación adecuada de los datos.
* Se agregó el controlador `getMovieReviewById` en el paquete de controladores para permitir la obtención de una reseña de película por su ID.
* Además, se plantea una sugerencia para futuras iteraciones del proyecto:
* Se podría considerar la implementación de Redis para cachear las respuestas de las consultas de reseñas de películas, lo que potencialmente mejoraría significativamente el rendimiento del sistema al reducir la latencia en la recuperación de datos.