### PR TITLE
feat: implement method deleteReviewById

### DIFF
--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/in/MovieReviewUseCase.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/in/MovieReviewUseCase.java
@@ -1,13 +1,12 @@
 package com.peliculas.peliculasapp.application.ports.in;
 import com.peliculas.peliculasapp.domain.models.MovieReview;
 import com.peliculas.peliculasapp.domain.dto.MovieReviewDTO;
-
 import java.util.List;
 import java.util.Optional;
 
 public interface MovieReviewUseCase {
     Optional<MovieReviewDTO> createMovieReview(MovieReview movieReview);
     Optional<MovieReview> updateMovieReview(MovieReview review);
-    List<MovieReviewDTO> findReviewsByMovieId(long reviewId);
-    Optional<MovieReview> deleteReviewById(long reviewId);
+    List<MovieReviewDTO> findAllReviewsByMovieId(long reviewId);
+    void deleteReviewById(long reviewId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieReviewRepositoryPort.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/ports/out/MovieReviewRepositoryPort.java
@@ -1,12 +1,12 @@
 package com.peliculas.peliculasapp.application.ports.out;
 import com.peliculas.peliculasapp.domain.models.MovieReview;
-
 import java.util.List;
 import java.util.Optional;
 
 public interface MovieReviewRepositoryPort {
     Optional<MovieReview> createMovieReview(MovieReview review);
     Optional<MovieReview> updateMovieReview(MovieReview review);
-    List<MovieReview> findReviewsByMovieId(long reviewId);
-    Optional<MovieReview> deleteReviewById(long reviewId);
+    List<MovieReview> findAllReviewsByMovieId(long reviewId);
+    void deleteReviewById(long reviewId);
+    Optional<MovieReview> getMovieReviewById(long reviewId);
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/services/MovieReviewService.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/services/MovieReviewService.java
@@ -4,7 +4,6 @@ import com.peliculas.peliculasapp.domain.models.MovieReview;
 import com.peliculas.peliculasapp.domain.dto.MovieReviewDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -22,6 +21,10 @@ public class MovieReviewService {
     }
 
     public List<MovieReviewDTO> findReviewsByMovieId(long reviewId) {
-        return movieReviewUseCase.findReviewsByMovieId(reviewId);
+        return movieReviewUseCase.findAllReviewsByMovieId(reviewId);
+    }
+
+    public void deleteReviewById(long reviewId) {
+        movieReviewUseCase.deleteReviewById(reviewId);
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/MovieReviewUseCaseImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/application/usecases/MovieReviewUseCaseImpl.java
@@ -4,6 +4,7 @@ import com.peliculas.peliculasapp.application.ports.in.MovieReviewUseCase;
 import com.peliculas.peliculasapp.application.ports.out.MovieReviewRepositoryPort;
 import com.peliculas.peliculasapp.domain.models.MovieReview;
 import com.peliculas.peliculasapp.domain.dto.MovieReviewDTO;
+import com.peliculas.peliculasapp.infrastructure.adapter.exceptions.MovieReviewNotFoundException;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,15 +35,23 @@ public class MovieReviewUseCaseImpl implements MovieReviewUseCase {
     }
 
     @Override
-    public List<MovieReviewDTO> findReviewsByMovieId(long reviewId) {
-        List<MovieReview> movieReview = movieReviewRepositoryPort.findReviewsByMovieId(reviewId);
+    public List<MovieReviewDTO> findAllReviewsByMovieId(long reviewId) {
+        List<MovieReview> movieReview = movieReviewRepositoryPort.findAllReviewsByMovieId(reviewId);
         return movieReview.stream()
                 .map(movieReviewMapper::toDto)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public Optional<MovieReview> deleteReviewById(long reviewId) {
-        return Optional.empty();
+    public void deleteReviewById(long reviewId) {
+        Optional<MovieReview> optionalMovieReview = movieReviewRepositoryPort.getMovieReviewById(reviewId);
+        optionalMovieReview.ifPresentOrElse(
+                movieReview -> {
+                    movieReviewRepositoryPort.deleteReviewById(movieReview.getId());
+                },
+                () -> {
+                    throw new MovieReviewNotFoundException("No se encontró ninguna reseña de película con el ID: " + reviewId);
+                }
+        );
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepository.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepository.java
@@ -14,5 +14,6 @@ public interface MovieReviewRepository extends JpaRepository<MovieReviewEntity, 
             "JOIN FETCH r.user u " +
             "JOIN FETCH r.movie m " +
             "WHERE r.movie.id = :movieId")
-    List<MovieReviewEntity> findReviewsByMovieId(@Param("movieId") long movieId);
+    List<MovieReviewEntity> findAllReviewsByMovieId(@Param("movieId") long movieId);
+
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepositoryJpaImpl.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/adapter/repositories/MovieReviewRepositoryJpaImpl.java
@@ -5,6 +5,7 @@ import com.peliculas.peliculasapp.infrastructure.adapter.entities.MovieEntity;
 import com.peliculas.peliculasapp.infrastructure.adapter.entities.UserEntity;
 import com.peliculas.peliculasapp.infrastructure.adapter.entities.MovieReviewEntity;
 import com.peliculas.peliculasapp.infrastructure.adapter.exceptions.MovieNotFoundException;
+import com.peliculas.peliculasapp.infrastructure.adapter.exceptions.MovieReviewNotFoundException;
 import com.peliculas.peliculasapp.infrastructure.adapter.exceptions.UserNotFoundException;
 import com.peliculas.peliculasapp.infrastructure.adapter.mapper.MovieReviewMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,16 +60,26 @@ public class MovieReviewRepositoryJpaImpl implements MovieReviewRepositoryPort {
     }
 
     @Override
-    public List<MovieReview> findReviewsByMovieId(long reviewId) {
-        List<MovieReviewEntity> movieReviewEntities = movieReviewRepository.findReviewsByMovieId(reviewId);
+    public Optional<MovieReview> getMovieReviewById(long reviewId) {
+       Optional<MovieReviewEntity> movieReview = movieReviewRepository.findById(reviewId);
+        return movieReview.map(movieReviewMapper::toDomainModel);
+    }
+
+    @Override
+    public List<MovieReview> findAllReviewsByMovieId(long reviewId) {
+        List<MovieReviewEntity> movieReviewEntities = movieReviewRepository.findAllReviewsByMovieId(reviewId);
         return movieReviewEntities.stream()
                 .map(movieReviewMapper::toDomainModel)
                 .toList();
     }
 
     @Override
-    public Optional<MovieReview> deleteReviewById(long reviewId) {
-        // TODO: Implement
-        return Optional.empty();
+    public void deleteReviewById(long reviewId) {
+        Optional<MovieReviewEntity> optionalMovieReview = movieReviewRepository.findById(reviewId);
+        if (optionalMovieReview.isPresent()) {
+            movieReviewRepository.deleteById(reviewId);
+        } else {
+            throw new MovieReviewNotFoundException("La reseña de película con el ID " + reviewId + " no se encontró.");
+        }
     }
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/rest/advice/MyControllerAdvice.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/rest/advice/MyControllerAdvice.java
@@ -43,4 +43,10 @@ public class MyControllerAdvice {
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.CONFLICT.value(), "Este email ya esta registrado", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT.value()).body(errorResponse);
     }
+    @ExceptionHandler(MovieReviewNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlerMovieReviewNotFoundException(MovieReviewNotFoundException e) {
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Review no encontrada", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
 }

--- a/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/rest/controllers/MovieReviewController.java
+++ b/peliculas-app/src/main/java/com/peliculas/peliculasapp/infrastructure/rest/controllers/MovieReviewController.java
@@ -33,4 +33,11 @@ public class MovieReviewController {
         SuccessResponse successResponse = new SuccessResponse(HttpStatus.OK.value(), "Review obtenida con exito", movieReviewDTO);
         return ResponseEntity.ok(successResponse);
     }
+
+    @DeleteMapping("/movies/review/{reviewId}")
+    public ResponseEntity<?> deleteReviewById(@PathVariable long reviewId) {
+        movieReviewService.deleteReviewById(reviewId);
+        SuccessResponse successResponse = new SuccessResponse(HttpStatus.OK.value(), "Review eliminada con exito", "Se elimino la review");
+        return ResponseEntity.ok(successResponse);
+    }
 }


### PR DESCRIPTION
### Cambios realizados:

* Implementación del método `deleteReviewById` en la interfaz `MovieReviewRepositoryPort` para permitir la eliminación de reseñas de películas.

* Implementación del método `deleteReviewById` en la interfaz `MovieReviewUseCase` para manejar la eliminación de reseñas de películas en la capa de casos de uso.

* Cambio de nombre del método `findReviewsByMovieId` a `findAllReviewsByMovieId` en la interfaz `MovieReviewRepositoryPort` para reflejar mejor su funcionalidad.

* Adición del método `getMovieReviewById` a la interfaz `MovieReviewRepositoryPort` para permitir la recuperación de reseñas de películas por su ID.

* Creación de la excepción `MovieReviewNotFoundException` para manejar los casos en los que una reseña de película no se encuentra en la base de datos.

* Agregado del manejo de excepciones `MovieReviewNotFoundException` al `ControllerAdvice` para proporcionar una respuesta adecuada cuando una reseña de película no se encuentra.

* Creación de un controlador que permite eliminar reseñas de películas.